### PR TITLE
DO NOT MERGE: API Test using ZAP

### DIFF
--- a/tests/zap/README.rst
+++ b/tests/zap/README.rst
@@ -1,0 +1,35 @@
+*********************
+API Testing using ZAP
+*********************
+
+ZAP (https://code.google.com/p/zaproxy/) can be used to complement the API Tests by providing basic penetration/security testing of the API
+
+Pre-requisites
+--------------
+
+#) ZAP (Zed Attack Proxy) must be configured and running. This can be done locally or on a remote server. ZAP requires Java
+
+#) Setting up the Deuce API Tests. The ZAP test takes advantage of the Deuce API Tests (configuration, client code). Please follow the instructions to set up the Deuce API Tests
+
+Configuration
+-------------
+
+The configuration file (zap/config.cfg) only has a couple of values:
+
+    **proxy** - URL to ZAP. If running locally, it will be http://127.0.0.1:8080
+
+    **attacklevel** - ZAP's Active Scan attack level. The values can be LOW, MEDIUM, HIGH, INSANE
+
+Running the test
+----------------
+
+ZAP can be started in headless mode by running::
+
+    ./zap.sh -daemon
+
+To run the test::
+
+    cd deuce/tests
+    nosetests -s -v --with-xunit --nologcapture zap
+
+The test script will shut down ZAP at the end

--- a/tests/zap/config.cfg
+++ b/tests/zap/config.cfg
@@ -1,0 +1,4 @@
+[zap]
+proxy=http://127.0.0.1:8080
+attacklevel=HIGH
+

--- a/tests/zap/config.py
+++ b/tests/zap/config.py
@@ -1,0 +1,18 @@
+import ConfigParser
+
+
+class ZapConfig(object):
+
+    def __init__(self):
+        self.config = ConfigParser.ConfigParser()
+        self.config.read('zap/config.cfg')
+
+    @property
+    def proxy_url(self):
+        """URL to ZAP"""
+        return self.config.get('zap', 'proxy')
+
+    @property
+    def attack_level(self):
+        """ZAP Active Scan Level. LOW, MEDIUM, HIGH, INSANE"""
+        return self.config.get('zap', 'attacklevel')

--- a/tests/zap/requirements.txt
+++ b/tests/zap/requirements.txt
@@ -1,0 +1,1 @@
+python-owasp-zap-v2

--- a/tests/zap/test_deuce_with_zap.py
+++ b/tests/zap/test_deuce_with_zap.py
@@ -1,4 +1,5 @@
 from tests.api import base
+import config
 
 import os
 import time
@@ -10,13 +11,15 @@ class TestZAP(base.TestBase):
 
     def setUp(self):
         super(TestZAP, self).setUp()
+        cfg = config.ZapConfig()
+
         # Configure ZAP
         self.http_proxy = os.environ.get('HTTP_PROXY')
-        os.environ['HTTP_PROXY'] = 'http://127.0.0.1:8080'
+        os.environ['HTTP_PROXY'] = cfg.proxy_url
         self.zap = ZAPv2()
         self.zap.ascan.enable_all_scanners()
         # self.zap.ascan.set_option_attack_strength('INSANE')
-        self.zap.ascan.set_option_attack_strength('HIGH')
+        self.zap.ascan.set_option_attack_strength(cfg.attack_level)
         for policy in self.zap.ascan.policies:
             if policy['enabled'] != 'true':
                 self.zap.ascan.set_enabled_policies([policy['id']])
@@ -88,3 +91,5 @@ class TestZAP(base.TestBase):
             del os.environ['HTTP_PROXY']
         else:
             os.environ['HTTP_PROXY'] = self.http_proxy
+        # shutdown ZAP
+        self.zap.core.shutdown()

--- a/tests/zap/test_deuce_with_zap.py
+++ b/tests/zap/test_deuce_with_zap.py
@@ -1,0 +1,90 @@
+from tests.api import base
+
+import os
+import time
+
+from zapv2 import ZAPv2
+
+class TestZAP(base.TestBase):
+
+    def setUp(self):
+        super(TestZAP, self).setUp()
+        # Configure ZAP
+        self.http_proxy = os.environ.get('HTTP_PROXY')
+        os.environ['HTTP_PROXY'] = 'http://127.0.0.1:8080'
+        self.zap = ZAPv2()
+        self.zap.ascan.enable_all_scanners()
+        # self.zap.ascan.set_option_attack_strength('INSANE')
+        self.zap.ascan.set_option_attack_strength('HIGH')
+        for policy in self.zap.ascan.policies:
+            if policy['enabled'] != 'true':
+                self.zap.ascan.set_enabled_policies([policy['id']])
+
+        # Deuce Api Calls (build site map for ZAP)
+        self.create_empty_vault()
+        self.create_new_file()
+        self.upload_multiple_blocks(nblocks=3)
+        self.assign_all_blocks_to_file()
+        self.finalize_file()
+
+        self.client.get_vault(self.vaultname)
+        self.client.vault_head(self.vaultname)
+        self.client.list_of_vaults()
+        self.client.list_of_vaults(marker=self.vaultname,
+                                   limit=80)
+
+        self.client.get_block(self.vaultname, self.blockid)
+        self.client.block_head(self.vaultname, self.blockid)
+        self.client.list_of_blocks(vaultname=self.vaultname)
+        self.client.list_of_blocks(vaultname=self.vaultname,
+                                   marker=self.blockid,
+                                   limit=80)
+
+        self.client.get_file(vaultname=self.vaultname, fileid=self.fileid)
+        self.client.list_of_blocks_in_file(vaultname=self.vaultname,
+                                           fileid=self.fileid)
+        self.client.list_of_blocks_in_file(vaultname=self.vaultname,
+                                           fileid=self.fileid,
+                                           marker=self.blockid,
+                                           limit=80)
+
+        self.client.list_of_files(vaultname=self.vaultname)
+        self.client.list_of_files(vaultname=self.vaultname,
+                                  marker=self.fileid,
+                                  limit=20)
+
+        self.client.get_storage_block(self.vaultname, self.storageid)
+        self.client.storage_block_head(self.vaultname, self.storageid)
+        self.client.list_of_storage_blocks(vaultname=self.vaultname)
+        self.client.list_of_storage_blocks(vaultname=self.vaultname,
+                                           marker=self.storageid,
+                                           limit=80)
+
+        self.client.delete_vault(self.vaultname)
+        self.client.delete_block(self.vaultname, self.blockid)
+        self.client.delete_file(self.vaultname, self.fileid)
+
+
+    def test_zap(self):
+
+        # Do an Active Scan on the main Deuce Url
+        self.zap_scan_url = self.zap.core.urls[0]
+        self.zap.ascan.scan(self.zap_scan_url, recurse='true')
+        while int(self.zap.ascan.status) < 100:
+            print('Scan progress {0}'.format(self.zap.ascan.status))
+            time.sleep(5)
+        print('Scan completed')    
+        alerts = self.zap.core.alerts()
+
+        # check against baseline
+        for alert in alerts:
+            if alert['risk'] != 'Low':
+                raise Exception(str(alerts))
+        if len(alerts) != 13:
+                raise Exception(str(alerts))
+
+    def tearDown(self):
+        if not self.http_proxy:
+            del os.environ['HTTP_PROXY']
+        else:
+            os.environ['HTTP_PROXY'] = self.http_proxy

--- a/tests/zap/test_deuce_with_zap.py
+++ b/tests/zap/test_deuce_with_zap.py
@@ -5,6 +5,7 @@ import time
 
 from zapv2 import ZAPv2
 
+
 class TestZAP(base.TestBase):
 
     def setUp(self):
@@ -64,7 +65,6 @@ class TestZAP(base.TestBase):
         self.client.delete_block(self.vaultname, self.blockid)
         self.client.delete_file(self.vaultname, self.fileid)
 
-
     def test_zap(self):
 
         # Do an Active Scan on the main Deuce Url
@@ -73,7 +73,7 @@ class TestZAP(base.TestBase):
         while int(self.zap.ascan.status) < 100:
             print('Scan progress {0}'.format(self.zap.ascan.status))
             time.sleep(5)
-        print('Scan completed')    
+        print('Scan completed')
         alerts = self.zap.core.alerts()
 
         # check against baseline


### PR DESCRIPTION
I've been thinking for a while that I would like to add a job to our CICD process that did some security validation of our APIs.

Zed Attack Proxy (https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) allows us to do a quick validation.
The script leverages the code created for the API tests and uses ZAP:
* creates a map of the Deuce API/site using ZAP as a proxy
* performs an active scan for all sorts of vulnerabilities

After setting up ZAP (which runs using Java), the execution with nosetests takes about 10 min., though the runtime can be increased/decreased based on the attach strength and the API coverage.

In order to use it with CI, we'd need a Jenkins slave in which ZAP is installed.
Have a job step start ZAP in daemon mode and execute the script. ZAP's shutdown can be handled by Jenkins or by the script.

I understand that the benefits are limited, but I do not think there are any downsides.
Thoughts?