### PR TITLE
feat: cassandra assign blocks now uses execute_async

### DIFF
--- a/deuce/drivers/metadatadriver.py
+++ b/deuce/drivers/metadatadriver.py
@@ -195,6 +195,15 @@ class MetadataStorageDriver(object):
         raise NotImplementedError
 
     @abstractmethod
+    def has_blocks(self, vault_id, block_ids):
+        """Determines if the vault has the specified blocks and
+        returns the missing blocks.
+        :param vault_id: ID of the vault
+        :param block_ids: list of block_id
+        :returns : list of missing blocks"""
+        raise NotImplementedError
+
+    @abstractmethod
     def assign_block(self, vault_id, file_id, block_id, offset):
         """Assigns the specified block to a particular offset in
         the file. No check is performed as to whether or not the
@@ -205,6 +214,19 @@ class MetadataStorageDriver(object):
         :param file_id: The ID of the file
         :param block_id: The ID of the block being assigned to the file
         :param offset: The position of the block in"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def assign_blocks(self, vault_id, file_id, block_ids, offsets):
+        """Assigns the specified blocks to a particular offsets in
+        the file. No check is performed as to whether or not the
+        blocks overlap (it can't be done since a block that doesn't
+        yet exist in storage can be assigned to a file).
+
+        :param vault_id: The vault containing the file
+        :param file_id: The ID of the file
+        :param block_ids: The IDs of the blocks being assigned to the file
+        :param offsets: The positions of the blocks"""
         raise NotImplementedError
 
     @abstractmethod

--- a/deuce/tests/mock_cassandra/__init__.py
+++ b/deuce/tests/mock_cassandra/__init__.py
@@ -1,9 +1,16 @@
-
-
 import deuce.drivers.cassandra.cassandrametadatadriver \
     as actual_driver
 
 import uuid
+
+
+class Future(object):
+
+    def __init__(self, result):
+        self._result = result
+
+    def result(self):
+        return [element for element in self._result]
 
 
 class Session(object):
@@ -80,3 +87,73 @@ class Session(object):
         res = list(res)
 
         return res
+
+    def execute_async(self, query, queryargs):
+        # Health check.
+        if 'system.local' in query:
+            return 'true'
+
+        original_query = query
+
+        query = query.replace('false', '0')
+        query = query.replace('true', '1')
+
+        if isinstance(queryargs, tuple):
+
+            # convert UUID to string
+            queryargs = tuple([str(s) if isinstance(s, uuid.UUID)
+                           else s for s in queryargs])
+
+            # sqlite prefers ? over %s for positional args
+            query = query.replace('%s', '?')
+
+        elif isinstance(queryargs, dict):
+
+            # If the user passed dictionary arguments, assume that they
+            # used that cassandra %(fieldname)s and convert to sqlite's
+            # :fieldname
+
+            for k, v in queryargs.items():
+                cass_style_arg = "%({0})s".format(k)
+                sqlite_style_arg = ":{0}".format(k)
+                query = query.replace(cass_style_arg, sqlite_style_arg)
+
+                # Convert UUID parameters to strings
+                if isinstance(v, uuid.UUID):
+                    queryargs[k] = str(v)
+
+        if original_query == actual_driver.CQL_INC_BLOCK_REF_COUNT:
+
+            # Special-case this query, since sqlite doesn't
+            # support upserts
+
+            insert_query = """
+                INSERT or IGNORE into blockreferences
+                (projectid, vaultid, blockid, refcount)
+                VALUES
+                (:projectid, :vaultid, :blockid, :refcount)
+            """
+
+            insert_args = queryargs.copy()
+            insert_args.update({'refcount': 0})
+            del insert_args["delta"]
+
+            self.conn.execute(insert_query, insert_args)
+
+        elif original_query == actual_driver.CQL_UPDATE_REF_TIME or \
+                original_query == actual_driver.CQL_REGISTER_BLOCK:
+
+            # unixTimeStampOf() and now() are not part of SQLite
+            query = query.replace('unixTimeStampOf(now())',
+                                  "strftime('%s', 'now')")
+
+        elif original_query == actual_driver.CQL_HEALTH_CHECK:
+
+            # neither now() nor system.local are part of sqlite
+            # So the following gives us the same query as the original
+            query = "SELECT strftime('%s', 'now')"
+
+        res = self.conn.execute(query, queryargs)
+        # res = list(res)
+
+        return Future(res)

--- a/deuce/tests/mock_cassandra/__init__.py
+++ b/deuce/tests/mock_cassandra/__init__.py
@@ -89,71 +89,7 @@ class Session(object):
         return res
 
     def execute_async(self, query, queryargs):
-        # Health check.
-        if 'system.local' in query:
-            return 'true'
 
-        original_query = query
-
-        query = query.replace('false', '0')
-        query = query.replace('true', '1')
-
-        if isinstance(queryargs, tuple):
-
-            # convert UUID to string
-            queryargs = tuple([str(s) if isinstance(s, uuid.UUID)
-                           else s for s in queryargs])
-
-            # sqlite prefers ? over %s for positional args
-            query = query.replace('%s', '?')
-
-        elif isinstance(queryargs, dict):
-
-            # If the user passed dictionary arguments, assume that they
-            # used that cassandra %(fieldname)s and convert to sqlite's
-            # :fieldname
-
-            for k, v in queryargs.items():
-                cass_style_arg = "%({0})s".format(k)
-                sqlite_style_arg = ":{0}".format(k)
-                query = query.replace(cass_style_arg, sqlite_style_arg)
-
-                # Convert UUID parameters to strings
-                if isinstance(v, uuid.UUID):
-                    queryargs[k] = str(v)
-
-        if original_query == actual_driver.CQL_INC_BLOCK_REF_COUNT:
-
-            # Special-case this query, since sqlite doesn't
-            # support upserts
-
-            insert_query = """
-                INSERT or IGNORE into blockreferences
-                (projectid, vaultid, blockid, refcount)
-                VALUES
-                (:projectid, :vaultid, :blockid, :refcount)
-            """
-
-            insert_args = queryargs.copy()
-            insert_args.update({'refcount': 0})
-            del insert_args["delta"]
-
-            self.conn.execute(insert_query, insert_args)
-
-        elif original_query == actual_driver.CQL_UPDATE_REF_TIME or \
-                original_query == actual_driver.CQL_REGISTER_BLOCK:
-
-            # unixTimeStampOf() and now() are not part of SQLite
-            query = query.replace('unixTimeStampOf(now())',
-                                  "strftime('%s', 'now')")
-
-        elif original_query == actual_driver.CQL_HEALTH_CHECK:
-
-            # neither now() nor system.local are part of sqlite
-            # So the following gives us the same query as the original
-            query = "SELECT strftime('%s', 'now')"
-
-        res = self.conn.execute(query, queryargs)
-        # res = list(res)
+        res = self.execute(query, queryargs)
 
         return Future(res)

--- a/deuce/transport/wsgi/v1_0/fileblocks.py
+++ b/deuce/transport/wsgi/v1_0/fileblocks.py
@@ -81,20 +81,10 @@ class CollectionResource(object):
         body = req.stream.read(req.content_length)
         # TODO (TheSriram): Validate payload
         payload = json.loads(body.decode())
+        block_ids, offsets = zip(*payload)
 
-        missing_blocks = list()
-
-        for mapping in payload:
-            # NOTE(TheSriram): payload is a list of lists of the form
-            # [[block,offset],[block,offset],[block,offset]]
-            block_id, offset = mapping
-
-            if not deuce.metadata_driver.has_block(vault_id, block_id):
-
-                missing_blocks.append(block_id)
-
-            deuce.metadata_driver.assign_block(vault_id, file_id,
-                                               block_id,
-                                               offset)
+        missing_blocks = deuce.metadata_driver.has_blocks(vault_id, block_ids)
+        deuce.metadata_driver.assign_blocks(vault_id, file_id, block_ids,
+                                            offsets)
 
         resp.body = json.dumps(missing_blocks)


### PR DESCRIPTION
- Memoization needs to be added, since functools'  lru_cache
  does not support invalidation per arg,kwarg pair