### PR TITLE
Remember block errors

### DIFF
--- a/deuce/drivers/cassandra/cassandrametadatadriver.py
+++ b/deuce/drivers/cassandra/cassandrametadatadriver.py
@@ -614,6 +614,10 @@ class CassandraStorageDriver(MetadataStorageDriver):
         if len(result) == 0:  # No blocks exist
             return False
 
+        # There should be exactly one row and one column
+        assert len(result) == 1
+        assert len(result[0]) == 1
+
         if check_status and result[0][0] is True:
             return False
 

--- a/deuce/drivers/cassandra/schema.cql
+++ b/deuce/drivers/cassandra/schema.cql
@@ -18,11 +18,15 @@ CREATE COLUMNFAMILY blocks (
   storageid TEXT,
   blocksize INT,
   reftime BIGINT,
+  isinvalid BOOLEAN,
   PRIMARY KEY((projectid, vaultid), blockid)
 );
 
 CREATE INDEX storageid_index
     on blocks (storageid);
+
+CREATE INDEX invalid_block_index
+    on blocks (isinvalid);
 
 CREATE TABLE files (
   projectid TEXT,

--- a/deuce/drivers/metadatadriver.py
+++ b/deuce/drivers/metadatadriver.py
@@ -190,17 +190,35 @@ class MetadataStorageDriver(object):
         raise NotImplementedError
 
     @abstractmethod
-    def has_block(self, vault_id, block_id):
-        """Determines if the vault has the specified block."""
+    def mark_block_as_bad(self, vault_id, block_id, check_status=False):
+        """Marks the block in the metadata driver as being a bad
+        block."""
         raise NotImplementedError
 
     @abstractmethod
-    def has_blocks(self, vault_id, block_ids):
+    def has_block(self, vault_id, block_id, check_status=False):
+        """Determines if the vault has the specified block.
+
+        :param vault_id: The vault to check for the block
+        :param block_id: The ID of the block to check for
+        :param check_status: Determines whether or not to determine
+            the status of the block. If True, and the block was
+            previously marked as being 'bad', this function will
+            return False. If check_status is False, the status
+            of the block is not considered at all"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def has_blocks(self, vault_id, block_ids, check_status=False):
         """Determines if the vault has the specified blocks and
-        returns the missing blocks.
+        returns the missing blocks
+
         :param vault_id: ID of the vault
         :param block_ids: list of block_id
-        :returns : list of missing blocks"""
+        :param check_status: Whether or not to consider the status
+           of the block. See parameter ``check_status`` in
+           function ``has_block`` for explanation.
+        :returns: list of missing blocks ids"""
         raise NotImplementedError
 
     @abstractmethod

--- a/deuce/drivers/sqlite/sqlitemetadatadriver.py
+++ b/deuce/drivers/sqlite/sqlitemetadatadriver.py
@@ -617,6 +617,11 @@ class SqliteStorageDriver(MetadataStorageDriver):
         if len(res) == 0:
             return False
 
+        # The result should contain exactly
+        # one row and one column.
+        assert len(res) == 1
+        assert len(res[0]) == 1
+
         if check_status and res[0][0] == 1:
             return False
 

--- a/deuce/model/vault.py
+++ b/deuce/model/vault.py
@@ -125,6 +125,11 @@ class Vault(object):
         if self._meta_has_block(block_id):
             if check_storage:
                 if not self._storage_has_block(block_id):
+
+                    # Record in metadata that the block is bad
+                    deuce.metadata_driver.mark_block_as_bad(
+                        self.id, block_id)
+
                     raise ConsistencyError(deuce.context.project_id,
                                            self.id, block_id,
                                            msg='Block does not exist'

--- a/deuce/tests/mock_cassandra/__init__.py
+++ b/deuce/tests/mock_cassandra/__init__.py
@@ -86,6 +86,18 @@ class Session(object):
         res = self.conn.execute(query, queryargs)
         res = list(res)
 
+        if original_query == actual_driver.CQL_GET_BLOCK_STATUS:
+            # Special-case the return value of this query. Returns
+            # 1 or 0 and should be true or false
+            if res == [(0,)]:
+                res = [(False,)]
+            elif res == [(1,)]:
+                res = [(True,)]
+            elif res == []:
+                pass  # Do nothing
+            else:
+                raise Exception("Unexpected result")
+
         return res
 
     def execute_async(self, query, queryargs):

--- a/deuce/tests/mock_cassandra/cluster.py
+++ b/deuce/tests/mock_cassandra/cluster.py
@@ -17,6 +17,7 @@ CREATE TABLE blocks (
   storageid TEXT,
   blocksize INT,
   reftime DATETIME,
+  isinvalid BOOLEAN,
   PRIMARY KEY(projectid, vaultid, blockid)
 );
 """, """

--- a/deuce/tests/test_cassandra_storage_driver.py
+++ b/deuce/tests/test_cassandra_storage_driver.py
@@ -4,6 +4,8 @@ from deuce import conf
 
 from mock import patch
 
+import unittest
+
 # Explanation:
 #   - The SqliteStorageDriver is the reference metadata driver. All
 # other drivers should conform to the same interface, therefore
@@ -17,6 +19,9 @@ class CassandraStorageDriverTest(SqliteStorageDriverTest):
     def create_driver(self):
         return CassandraStorageDriver()
 
+    @unittest.skipIf(conf.metadata_driver.cassandra.testing.is_mocking is False
+       and conf.metadata_driver.cassandra.ssl_enabled is False,
+       "Don't run the test if we are running without SSL")
     def test_create_driver_auth_ssl(self):
         with patch.object(conf.metadata_driver.cassandra, 'ssl_enabled',
                           return_value=True):


### PR DESCRIPTION
This patch causes the metadata driver to remember block errors if they occur during a block check (in other words, during a HEAD operation on the block).

This PR has no user-facing changes to the API (recording of bad blocks has no impact). Those will be implemented in the future. 