### PR TITLE
Bugfix hook backend detection

### DIFF
--- a/deuce/drivers/disk/diskstoragedriver.py
+++ b/deuce/drivers/disk/diskstoragedriver.py
@@ -25,7 +25,7 @@ class DiskStorageDriver(BlockStorageDriver):
     block_permission = 0o640
 
     def __init__(self):
-        self._path = conf.block_storage_driver.options.path
+        self._path = conf.block_storage_driver.disk.path
 
     def _get_vault_path(self, vault_id):
         return os.path.join(self._path, str(deuce.context.project_id),

--- a/deuce/model/__init__.py
+++ b/deuce/model/__init__.py
@@ -18,6 +18,18 @@ deuce.storage_driver = None
 deuce.metadata_driver = None
 
 
+class BadDriverException(Exception):
+    pass
+
+
+class BadStorageDriverException(BadDriverException):
+    pass
+
+
+class BadMetadataDriverException(BadDriverException):
+    pass
+
+
 def _load_driver(classname):
     """Creates of the instance of the specified
     class given the fully-qualified name. The module
@@ -31,7 +43,25 @@ def _load_driver(classname):
     return getattr(mod, class_name)()
 
 
+def _load_metadata_driver(driver_name):
+    if hasattr(conf.metadata_driver, driver_name):
+        return _load_driver(getattr(conf.metadata_driver, driver_name).driver)
+    else:
+        raise BadMetadataDriverException('Unknown Metadata driver {0}'
+                                         .format(driver_name))
+
+
+def _load_storage_driver(driver_name):
+    if hasattr(conf.block_storage_driver, driver_name):
+        return _load_driver(getattr(conf.block_storage_driver, driver_name)
+                            .driver)
+    else:
+        raise BadStorageDriverException('Unknown Storage driver {0}'
+                                        .format(driver_name))
+
+
 def init_model():
     # Load metadata driver
-    deuce.metadata_driver = _load_driver(conf.metadata_driver.driver)
-    deuce.storage_driver = _load_driver(conf.block_storage_driver.driver)
+    deuce.metadata_driver = _load_metadata_driver(conf.metadata_driver.driver)
+    deuce.storage_driver = _load_storage_driver(
+        conf.block_storage_driver.driver)

--- a/deuce/tests/__init__.py
+++ b/deuce/tests/__init__.py
@@ -67,7 +67,7 @@ class TestBase(unittest.TestCase):
         # This is required for environments that run multiple tests
         # at the same time, e.g. tox -e py34 in one shell and
         # tox -e py33 in another shell simultaneously, f.e Jenkins
-        deuce.conf.block_storage_driver.options.path = \
+        deuce.conf.block_storage_driver.disk.path = \
             test_disk_storage_location
 
         self.app = Driver().app

--- a/deuce/tests/test_model_init.py
+++ b/deuce/tests/test_model_init.py
@@ -1,0 +1,36 @@
+import unittest
+
+from deuce.tests import *
+from deuce.model import (
+    init_model,
+    _load_storage_driver,
+    _load_metadata_driver,
+    BadStorageDriverException,
+    BadMetadataDriverException
+)
+
+
+class TestModelInit(V1Base):
+
+    def setUp(self):
+        super(TestModelInit, self).setUp()
+        import deuce
+        deuce.metadata_driver = None
+        deuce.storage_driver = None
+
+    def tearDown(self):
+        super(TestModelInit, self).tearDown()
+        import deuce
+        deuce.metadata_driver = None
+        deuce.storage_driver = None
+
+    def test_load_drivers(self):
+        init_model()
+
+    def test_load_bad_metadata_driver(self):
+        with self.assertRaises(BadMetadataDriverException):
+            _load_metadata_driver('bad metadata driver')
+
+    def test_load_bad_storage_driver(self):
+        with self.assertRaises(BadStorageDriverException):
+            _load_storage_driver('bad storage driver')

--- a/deuce/tests/test_model_init.py
+++ b/deuce/tests/test_model_init.py
@@ -1,5 +1,3 @@
-import unittest
-
 from deuce.tests import *
 from deuce.model import (
     init_model,

--- a/deuce/tests/test_wsgi_driver.py
+++ b/deuce/tests/test_wsgi_driver.py
@@ -1,12 +1,15 @@
 from unittest import TestCase
 
+import ddt
 from mock import patch
 from wsgiref import simple_server
 
+import deuce
 from deuce.transport.wsgi.driver import Driver
 import deuce.util.log as logging
 
 
+@ddt.ddt
 class TestDriver(TestCase):
 
     def test_driver(self):
@@ -20,5 +23,20 @@ class TestDriver(TestCase):
         with patch.object(simple_server,
                           'make_server',
                           return_value=mock_server_object):
-            app_container = Driver()
-            app_container.listen()
+                app_container = Driver()
+                app_container.listen()
+
+    @ddt.data('disk', 'swift')
+    def test_hooks(self, hook_set):
+        class DummyWsgi(object):
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def set_header(self, *args, **kwargs):
+                pass
+
+        from deuce import conf
+        conf.block_storage_driver.driver = hook_set
+        dummy_wsgi = DummyWsgi()
+        Driver.before_hooks(dummy_wsgi)

--- a/deuce/transport/wsgi/driver.py
+++ b/deuce/transport/wsgi/driver.py
@@ -19,25 +19,20 @@ class Driver(object):
         self._init_routes()
         model.init_model()
 
-    def before_hooks(self, req, resp, params):
+    def before_hooks(self):
 
-        # Disk + Sqlite
-
-        return [
-            hooks.DeuceContextHook(req, resp, params),
-            hooks.TransactionidHook(req, resp, params),
-            hooks.ProjectidHook(req, resp, params)
+        hook_list = [
+            hooks.DeuceContextHook,
+            hooks.TransactionidHook,
+            hooks.ProjectidHook
         ]
 
-        # Swift
+        if conf.block_storage_driver.driver == 'swift':
+            # Swift
+            hook_list.append(hooks.OpenstackHook)
+            hook_list.append(hooks.OpenstackSwiftHook)
 
-        # return [
-        #     hooks.DeuceContextHook(req, resp, params),
-        #     hooks.TransactionidHook(req, resp, params),
-        #     hooks.ProjectidHook(req, resp, params),
-        #     hooks.OpenstackHook(req, resp, params),
-        #     hooks.OpenstackSwiftHook(req, resp, params)
-        # ]
+        return hook_list
 
     def _init_routes(self):
         """Initialize hooks and URI routes to resources."""
@@ -47,7 +42,7 @@ class Driver(object):
 
         ]
 
-        self.app = falcon.API(before=self.before_hooks)
+        self.app = falcon.API(before=self.before_hooks())
 
         for version_path, endpoints in endpoints:
             for route, resource in endpoints:

--- a/ini/config.ini
+++ b/ini/config.ini
@@ -43,8 +43,9 @@ log_directory = log
         format = '%(asctime)s %(levelname)-5.5s [%(name)s/%(lineno)d][%(threadName)s] [%(request_id)s] : %(message)s'
 
 [block_storage_driver]
-driver = deuce.drivers.disk.DiskStorageDriver
-    [[options]]
+driver = disk
+    [[disk]]
+		driver = deuce.drivers.disk.DiskStorageDriver
         path = /tmp/block_storage
     [[swift]]
         driver = deuce.drivers.swift.SwiftStorageDriver
@@ -57,8 +58,9 @@ driver = deuce.drivers.disk.DiskStorageDriver
             storage_url = Storage Url
 
 [metadata_driver]
-driver = deuce.drivers.sqlite.SqliteStorageDriver
+driver = sqlite
     [[cassandra]]
+		driver = deuce.drivers.cassandra.CassandraStorageDriver
         cluster = 127.0.0.1,
         keyspace = deucekeyspace
         db_module = cassandra
@@ -71,9 +73,11 @@ driver = deuce.drivers.sqlite.SqliteStorageDriver
         [[[testing]]]
             is_mocking = True
     [[sqlite]]
+		driver = deuce.drivers.sqlite.SqliteStorageDriver
         path = :memory:
         db_module = sqlite3
     [[mongodb]]
+		driver = deuce.drivers.mongodb.MongoDbStorageDriver
         path = deuce_mongo_unittest_vaultmeta
         url = mongodb://127.0.0.1
         db_file = /tmp/deuce_mongo_unittest_vaultmeta.db

--- a/ini/config.ini
+++ b/ini/config.ini
@@ -45,7 +45,7 @@ log_directory = log
 [block_storage_driver]
 driver = disk
     [[disk]]
-		driver = deuce.drivers.disk.DiskStorageDriver
+        driver = deuce.drivers.disk.DiskStorageDriver
         path = /tmp/block_storage
     [[swift]]
         driver = deuce.drivers.swift.SwiftStorageDriver
@@ -60,7 +60,7 @@ driver = disk
 [metadata_driver]
 driver = sqlite
     [[cassandra]]
-		driver = deuce.drivers.cassandra.CassandraStorageDriver
+        driver = deuce.drivers.cassandra.CassandraStorageDriver
         cluster = 127.0.0.1,
         keyspace = deucekeyspace
         db_module = cassandra
@@ -73,11 +73,11 @@ driver = sqlite
         [[[testing]]]
             is_mocking = True
     [[sqlite]]
-		driver = deuce.drivers.sqlite.SqliteStorageDriver
+        driver = deuce.drivers.sqlite.SqliteStorageDriver
         path = :memory:
         db_module = sqlite3
     [[mongodb]]
-		driver = deuce.drivers.mongodb.MongoDbStorageDriver
+        driver = deuce.drivers.mongodb.MongoDbStorageDriver
         path = deuce_mongo_unittest_vaultmeta
         url = mongodb://127.0.0.1
         db_file = /tmp/deuce_mongo_unittest_vaultmeta.db

--- a/ini/configspec.ini
+++ b/ini/configspec.ini
@@ -9,17 +9,36 @@ datacenter = string
 default_returned_num = integer
 max_returned_num = integer
 [metadata_driver]
+driver = string
+    [[sqlite]]
+    driver = string
+	path = string
+	db_module = string
     [[mongodb]]
+    driver = string
+	path = string
+	url = string
+	db_file = string
+	db_module = string
     FileBlockReadSegNum = integer
     maxFileBlockSegNum = integer
         [[[testing]]]
         is_mocking = boolean
     [[cassandra]]
+    driver = string
+	cluster = string
+	keyspace = string
+	db_module = string
     ssl_enabled = boolean
     auth_enabled = boolean
         [[[testing]]]
         is_mocking = boolean
 [block_storage_driver]
+driver = string
+    [[disk]]
+    driver = string
+	path = string
     [[swift]]
+    driver = string
         [[[testing]]]
         is_mocking = boolean

--- a/ini/configspec.ini
+++ b/ini/configspec.ini
@@ -9,7 +9,7 @@ datacenter = string
 default_returned_num = integer
 max_returned_num = integer
 [metadata_driver]
-driver = string
+driver = option('sqlite', 'mongodb', 'cassandra')
     [[sqlite]]
     driver = string
 	path = string
@@ -26,7 +26,7 @@ driver = string
         is_mocking = boolean
     [[cassandra]]
     driver = string
-	cluster = string
+	cluster = string_list
 	keyspace = string
 	db_module = string
     ssl_enabled = boolean
@@ -34,7 +34,7 @@ driver = string
         [[[testing]]]
         is_mocking = boolean
 [block_storage_driver]
-driver = string
+driver = option('disk', 'swift')
     [[disk]]
     driver = string
 	path = string


### PR DESCRIPTION
- Bug Fix: Configuration File did not really have a 'disk' configuration. Updated it to do so.
- Bug Fix: The Hooks seemed to be loaded incorrectly; adjusted usage of loading the hooks through falcon.API() to be more inline with the Falcon documentation; Falcon now takes care of calling the hooks for us
- Enhancement: Updated the driver configurations so that the initial driver spec simply specifies a sub-section of the configuration for which to load the driver
  - f.e deuce.conf.metadata_driver.driver now is either 'sqlite', 'cassandra', or 'mongodb', the actual driver is specified in that section's driver, f.e deuce.conf.metadata_driver.sqlite.driver
  - raises an exception specific to the driver type if the specified driver for metadata or storage is not recognized
- Enhancement: Uses the deuce.conf.block_storage_driver.driver to determine whether to load the Swift Hooks
  - extensible so we could easily add other values as well
- Bug Fix: Updated the configspec.ini to map more of the values from the specific sections
  - these will typically be provided by default if the user copies the example config.ini and most won't need to be changed
- Enhancement: Updated configspec to use specific values for the drivers
- Enhancement: Updated configspec so the cassandra cluster address space is validated as a list of strings