### PR TITLE
fix: swift driver correctly recognizes missing blocks from storage as 40...

### DIFF
--- a/deuce/drivers/disk/diskstoragedriver.py
+++ b/deuce/drivers/disk/diskstoragedriver.py
@@ -1,3 +1,4 @@
+import bisect
 import io
 import os
 import os.path
@@ -59,9 +60,9 @@ class DiskStorageDriver(BlockStorageDriver):
             if marker:
                 try:
                     index = total_contents.index(marker)
-                    return total_contents[index:(index + limit)]
                 except ValueError:
-                    return []
+                    index = bisect.bisect(total_contents, marker)
+                return total_contents[index:(index + limit)]
             else:
                 return total_contents[:limit]
 

--- a/deuce/drivers/swift/swiftstoragedriver.py
+++ b/deuce/drivers/swift/swiftstoragedriver.py
@@ -184,9 +184,10 @@ class SwiftStorageDriver(BlockStorageDriver):
 
     def get_block_obj(self, vault_id, storage_block_id):
 
+        buff = BytesIO()
+        response = dict()
+
         try:
-            buff = BytesIO()
-            response = dict()
             # NOTE(TheSriram): block is a tuple of
             # headers and response body.
             block = self.Conn.get_object(
@@ -196,12 +197,13 @@ class SwiftStorageDriver(BlockStorageDriver):
                 name=str(storage_block_id),
                 response_dict=response)
 
-            if block[1]:
+            if response['status'] >= 200 and response['status'] < 300:
                 buff.write(block[1])
                 buff.seek(0)
                 return buff
             else:
                 return None
+
         except ClientException:
             return None
 
@@ -219,7 +221,8 @@ class SwiftStorageDriver(BlockStorageDriver):
                     name=str(storage_block_id),
                     response_dict=response)
 
-            return len(block[1])
+            return len(block[1]) if (response['status'] >= 200
+                                     and response['status'] < 300) else 0
 
         except ClientException:
             return 0

--- a/deuce/tests/db_mocking/swift_mocking/client.py
+++ b/deuce/tests/db_mocking/swift_mocking/client.py
@@ -244,6 +244,11 @@ def delete_object(url,
 
 
 # Get Block
+
+def _mock_status_code():
+    return 200
+
+
 def get_object(url,
             token,
             container,
@@ -254,20 +259,27 @@ def get_object(url,
 
     if not os.path.exists(path):
         raise ClientException('mocking')
-
-    buff = ""
-    with open(path, 'rb') as infile:
-        buff = infile.read()
-
-    mdhash = hashlib.md5()
-    mdhash.update(buff)
-    etag = mdhash.hexdigest()
-
     hdrs = {}
-    hdrs['content-length'] = os.path.getsize(path)
-    hdrs['last-modified'] = os.path.getmtime(path)
-    hdrs['accept-ranges'] = 'bytes'
-    hdrs['etag'] = etag
+    buff = ''
+
+    try:
+
+        with open(path, 'rb') as infile:
+            buff = infile.read()
+
+        mdhash = hashlib.md5()
+        mdhash.update(buff)
+        etag = mdhash.hexdigest()
+
+        hdrs['content-length'] = os.path.getsize(path)
+        hdrs['last-modified'] = os.path.getmtime(path)
+        hdrs['accept-ranges'] = 'bytes'
+        hdrs['etag'] = etag
+
+    except:
+        pass
+
+    response_dict['status'] = _mock_status_code()
     return hdrs, buff
 
 

--- a/deuce/tests/test_p3kswiftclient.py
+++ b/deuce/tests/test_p3kswiftclient.py
@@ -246,8 +246,8 @@ class Test_P3k_SwiftClient(V1Base):
             self.vault,
             self.block,
             self.response_dict)
-        self.assertEqual(file, response[1])
-        self.assertEqual(r.headers, response[0].headers)
+        self.assertEqual(file, response[0])
+        self.assertEqual(r.headers, response[1].headers)
 
     def test_delete_object(self):
         r = Response(204)

--- a/deuce/tests/test_swift_storage_driver.py
+++ b/deuce/tests/test_swift_storage_driver.py
@@ -19,13 +19,6 @@ from swiftclient.exceptions import ClientException
 
 class SwiftStorageDriverTest(DiskStorageDriverTest):
 
-    def setUp(self):
-        super(SwiftStorageDriverTest, self).setUp()
-        storage_url, auth_token = self.get_Auth_Token()
-        import deuce
-        deuce.context.openstack.auth_token = auth_token
-        deuce.context.openstack.swift.storage_url = storage_url
-
     def create_driver(self):
         return SwiftStorageDriver()
 

--- a/deuce/tests/test_swift_storage_driver.py
+++ b/deuce/tests/test_swift_storage_driver.py
@@ -1,7 +1,11 @@
 import six
+import sys
+import deuce
 from deuce.drivers.blockstoragedriver import BlockStorageDriver
 from deuce import conf
 import mock
+from mock import patch
+from unittest.mock import call
 from deuce.drivers.swift import SwiftStorageDriver
 
 from deuce.tests.test_disk_storage_driver import DiskStorageDriverTest
@@ -147,11 +151,15 @@ class SwiftStorageDriverTest(DiskStorageDriverTest):
             self.assertEqual(driver.get_block_object_length(vault_id,
                                                             block_id),
                              0)
+        with mock.patch(
+            'deuce.tests.db_mocking.swift_mocking.client._mock_status_code'
+        ) as mock_status:
 
-            get_object.side_effect = None
-            get_object.return_value = ({'x-header': 'mock'}, False)
+            with mock.patch('os.path.exists') as path_status:
+                path_status.return_value = True
+                mock_status.return_value = 500
 
-            self.assertIsNone(driver.get_block_obj(vault_id, block_id))
+                self.assertIsNone(driver.get_block_obj(vault_id, block_id))
 
         # Stats should come back as zero even though the connection
         # "dropped"

--- a/deuce/util/client.py
+++ b/deuce/util/client.py
@@ -194,7 +194,7 @@ def delete_object(url, token, container, name, response_dict):
 
 def get_object(url, token, container, name, response_dict):
     headers = {'X-Auth-Token': token}
-    (resp_headers, response) = _request_getobj(
+    (response, resp_headers) = _request_getobj(
         'GET',
         url +
         '/' +
@@ -202,5 +202,7 @@ def get_object(url, token, container, name, response_dict):
         '/' +
         str(name),
         headers=headers)
+
+    response_dict['status'] = response.status
 
     return (resp_headers, response)


### PR DESCRIPTION
...4s

- disk storage driver also makes sures that if given a marker (good in
  format) but not exisiting, supplies the elements after it in a
  sorted order