### PR TITLE
Bug Fix: Set correct permissions on the "project" folder in the disk driver

### DIFF
--- a/deuce/drivers/disk/diskstoragedriver.py
+++ b/deuce/drivers/disk/diskstoragedriver.py
@@ -27,9 +27,11 @@ class DiskStorageDriver(BlockStorageDriver):
     def __init__(self):
         self._path = conf.block_storage_driver.options.path
 
+    def _get_project_path(self):
+        return os.path.join(self._path, str(deuce.context.project_id))
+
     def _get_vault_path(self, vault_id):
-        return os.path.join(self._path, str(deuce.context.project_id),
-            vault_id)
+        return os.path.join(self._get_project_path(), vault_id)
 
     def _get_block_path(self, vault_id, storage_block_id):
         vault_path = self._get_vault_path(vault_id)
@@ -40,6 +42,8 @@ class DiskStorageDriver(BlockStorageDriver):
 
         if not os.path.exists(path):
             shutil.os.makedirs(path)
+            os.chmod(self._get_project_path(),
+                     DiskStorageDriver.vault_permission)
             os.chmod(path, DiskStorageDriver.vault_permission)
 
     def vault_exists(self, vault_id):


### PR DESCRIPTION
- Disk driver created multiple directories by joining CWD + ProjectID + Vault Name; however it only set permissions on the final directory, not the intermediate directory.

Note: Cherry-picked from PR #247. This is separate from the rest of what was in that PR.