### PR TITLE
Enhancement msgpack returns

### DIFF
--- a/deuce/model/vault.py
+++ b/deuce/model/vault.py
@@ -93,6 +93,8 @@ class Vault(object):
             block_ids,
             blockdatas)
 
+        retblocks = []
+
         # (BenjamenMeyer): If we fail to upload any one block then we
         # let the Validation and Clean-Up Service remove any uploaded blocks
         # and fail out the request as a whole
@@ -118,8 +120,9 @@ class Vault(object):
                     block_id,
                     storageid,
                     block_size)
+                retblocks.append((block_id, storageid))
 
-        return retval
+        return (retval, retblocks)
 
     def get_blocks(self, marker, limit):
         gen = deuce.metadata_driver.create_block_generator(

--- a/deuce/model/vault.py
+++ b/deuce/model/vault.py
@@ -107,6 +107,12 @@ class Vault(object):
                                                                   storage_ids,
                                                                   blockdatas,
                                                                   block_sizes):
+                logger.info('Project {0}, Vault {1}: Associating metadata '
+                            'block {2} with storage block {3}'
+                            .format(deuce.context.project_id,
+                                    self.id,
+                                    block_id,
+                                    storageid))
                 deuce.metadata_driver.register_block(
                     self.id,
                     block_id,

--- a/deuce/tests/test_blocks.py
+++ b/deuce/tests/test_blocks.py
@@ -57,7 +57,7 @@ class TestBlocksController(ControllerTest):
         self.assertEqual(self.srmock.status, falcon.HTTP_404)
 
     def test_get_invalid_block_id_swift_failure(self):
-        block_list = self.helper_create_blocks(1, async=True)
+        block_list = self.helper_create_blocks(1, async=True)[0]
         data = os.urandom(100)
         block_id = self.calc_sha1(data)
 
@@ -67,7 +67,7 @@ class TestBlocksController(ControllerTest):
         self.assertEqual(self.srmock.status, falcon.HTTP_404)
 
     def test_get_inconsistent_metadata_block_id(self):
-        block_list = self.helper_create_blocks(1, async=True)
+        block_list = self.helper_create_blocks(1, async=True)[0]
         data = os.urandom(100)
         block_id = self.calc_sha1(data)
 
@@ -96,7 +96,7 @@ class TestBlocksController(ControllerTest):
     def test_head_inconsistent_metadata_block_id(self):
         from deuce.model import Vault
         with patch.object(Vault, '_storage_has_block', return_value=False):
-            block_list = self.helper_create_blocks(1, async=True)
+            block_list = self.helper_create_blocks(1, async=True)[0]
             path = self.get_block_path(self.vault_name, block_list[0])
             self.simulate_head(path, headers=self._hdrs)
             self.assertEqual(self.srmock.status, falcon.HTTP_410)
@@ -111,7 +111,7 @@ class TestBlocksController(ControllerTest):
         self.assertEqual(self.srmock.status, falcon.HTTP_404)
 
     def test_head_block(self):
-        block_list = self.helper_create_blocks(1, async=True)
+        block_list = self.helper_create_blocks(1, async=True)[0]
         path = self.get_block_path(self.vault_name, block_list[0])
         self.simulate_head(path, headers=self._hdrs)
         self.assertEqual(self.srmock.status, falcon.HTTP_204)
@@ -160,7 +160,7 @@ class TestBlocksController(ControllerTest):
 
     def test_put_happy_case(self):
 
-        block_list = self.helper_create_blocks(num_blocks=1)
+        block_list = self.helper_create_blocks(num_blocks=1)[0]
         self.assertEqual(len(block_list), 1)
 
         self.assertEqual(self.srmock.status, falcon.HTTP_201)
@@ -241,7 +241,7 @@ class TestBlocksController(ControllerTest):
         self.assertEqual(self.srmock.status, falcon.HTTP_405)
 
     def test_with_bad_marker_and_limit(self):
-        block_list = self.helper_create_blocks(5)
+        block_list = self.helper_create_blocks(5)[0]
 
         # TODO: Need reenable after each function can cleanup/delete
         # blocks afterward.
@@ -298,10 +298,15 @@ class TestBlocksController(ControllerTest):
         self.assertEqual(self.srmock.status, falcon.HTTP_405)
 
         # Create 5 blocks
-        block_list = self.helper_create_blocks(num_blocks=5,
-                                               async=async_status)
+        block_list, response = self.helper_create_blocks(num_blocks=5,
+                                                         async=async_status)
         self.total_block_num = 5
         self.block_list += block_list
+
+        # verify all blocks in the block list also have an entry in
+        # the response list
+        if async_status is True:
+            self.helper_exam_block_metadata(block_list, response)
 
         # List all.
         next_batch_url = self.helper_get_blocks(path,
@@ -322,7 +327,7 @@ class TestBlocksController(ControllerTest):
 
         # Create more blocks.
         num_blocks = int(1.5 * conf.api_configuration.default_returned_num)
-        block_list = self.helper_create_blocks(num_blocks=num_blocks)
+        block_list = self.helper_create_blocks(num_blocks=num_blocks)[0]
         self.block_list += block_list
         self.total_block_num += num_blocks
 
@@ -366,7 +371,7 @@ class TestBlocksController(ControllerTest):
 
     def test_delete_blocks_no_references(self):
         # Just create and delete blocks
-        blocklist = self.helper_create_blocks(10)
+        blocklist = self.helper_create_blocks(10)[0]
         for block in blocklist:
             response = self.simulate_delete(
                 self.get_block_path(self.vault_name, block),
@@ -383,7 +388,7 @@ class TestBlocksController(ControllerTest):
             rel_url, querystring = relative_uri(
                 self.srmock.headers_dict['Location'])
             file_ids.append(rel_url)
-        block_list = self.helper_create_blocks(3, singleblocksize=True)
+        block_list = self.helper_create_blocks(3, singleblocksize=True)[0]
 
         offsets = [x * 100 for x in range(3)]
         data = list(zip(block_list, offsets))
@@ -410,7 +415,7 @@ class TestBlocksController(ControllerTest):
         from deuce.model import Vault
         with patch.object(Vault,
                           'put_async_block',
-                          return_value=False):
+                          return_value=(False, [])):
             self.helper_create_blocks(1, async=True)
             self.assertEqual(self.srmock.status, falcon.HTTP_500)
 
@@ -448,6 +453,7 @@ class TestBlocksController(ControllerTest):
         block_list = [self.calc_sha1(d) for d in data]
 
         block_data = zip(block_sizes, data, block_list)
+        response = None
         if async:
             contents = dict(zip(block_list, data))
             request_body = msgpack.packb(contents)
@@ -476,7 +482,7 @@ class TestBlocksController(ControllerTest):
                 response = self.simulate_put(path, headers=headers,
                                              body=data)
 
-        return block_list
+        return (block_list, response)
 
     def helper_get_blocks(self, path, marker, limit, assert_ret_url,
                           assert_data_len, repeat=False,
@@ -542,6 +548,30 @@ class TestBlocksController(ControllerTest):
 
             self.assertEqual(self.srmock.status, falcon.HTTP_200)
             self.assertIn('x-block-reference-count', str(self.srmock.headers))
+
+            # Now re-hash the data, the data that
+            # was returned should match the original
+            # sha1
+            z = hashlib.sha1()
+            z.update(response.read())
+            self.assertEqual(z.hexdigest(), sha1)
+
+    def helper_exam_block_metadata(self, block_list, upload_response):
+        # Now verify each uploaded block is there
+        uploaded_data = json.loads(upload_response[0].decode())
+        for sha1 in block_list:
+            self.assertIn(sha1, uploaded_data)
+
+            path = self.get_block_path(self.vault_name, sha1)
+            response = self.simulate_get(path, headers=self._hdrs)
+
+            self.assertEqual(self.srmock.status, falcon.HTTP_200)
+            self.assertIn('x-block-reference-count', str(self.srmock.headers))
+            # ensure each reported x-storage-id matches between the
+            # upload and download operations
+            self.assertIn('x-storage-id', str(self.srmock.headers))
+            self.assertEqual(uploaded_data[sha1],
+                             self.srmock.headers_dict['x-storage-id'])
 
             # Now re-hash the data, the data that
             # was returned should match the original

--- a/deuce/transport/wsgi/v1_0/blocks.py
+++ b/deuce/transport/wsgi/v1_0/blocks.py
@@ -224,6 +224,8 @@ class CollectionResource(object):
     @validate(vault_id=VaultGetRule)
     def on_post(self, req, resp, vault_id):
         vault = Vault.get(vault_id)
+        result_type = req.get_param_as_bool('mapping',
+                                            required=False)
         try:
             unpacked = msgpack.unpackb(req.stream.read())
 
@@ -238,10 +240,13 @@ class CollectionResource(object):
                         block_ids,
                         block_datas)
                     if retval:
-                        resp.status = falcon.HTTP_200
-                        resp.body = json.dumps({block_id: storage_id
-                                               for block_id, storage_id
-                                               in retblocks})
+                        if result_type:
+                            resp.status = falcon.HTTP_200
+                            resp.body = json.dumps({block_id: storage_id
+                                                   for block_id, storage_id
+                                                   in retblocks})
+                        else:
+                            resp.status = falcon.HTTP_201
                     else:
                         raise errors.HTTPInternalServerError('Block '
                                                             'Post Failed')

--- a/deuce/transport/wsgi/v1_0/blocks.py
+++ b/deuce/transport/wsgi/v1_0/blocks.py
@@ -234,11 +234,14 @@ class CollectionResource(object):
                 block_ids = list(unpacked.keys())
                 block_datas = list(unpacked.values())
                 try:
-                    retval = vault.put_async_block(
+                    retval, retblocks = vault.put_async_block(
                         block_ids,
                         block_datas)
                     if retval:
-                        resp.status = falcon.HTTP_201
+                        resp.status = falcon.HTTP_200
+                        resp.body = json.dumps({block_id: storage_id
+                                               for block_id, storage_id
+                                               in retblocks})
                     else:
                         raise errors.HTTPInternalServerError('Block '
                                                             'Post Failed')

--- a/tests/api/README.rst
+++ b/tests/api/README.rst
@@ -10,7 +10,7 @@ To run the tests:
    - jsonschema
    - opencafe
 
-#) Make a copy of *deuce/tests/api/etc/tests.conf.sample* and edit it with the appropriate information for the deuce base url of the environment being tested.
+#) Make a copy of *deuce/tests/etc/tests.conf.sample* and edit it with the appropriate information for the deuce base url of the environment being tested.
 #) Set up the following environment variables:
 
    - **CAFE_CONFIG_FILE_PATH** (points to the complete path to your test configuration file) 

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -372,7 +372,9 @@ class TestBase(fixtures.BaseTestFixture):
         data = dict([(block.Id, block.Data) for block in uploaded])
         msgpack_data = msgpack.packb(data)
         resp = self.client.upload_multiple_blocks(self.vaultname, msgpack_data)
-        if resp.status_code == 200:
+        if resp.status_code == 201:
+            return True
+        elif resp.status_code == 200:
             block_mapping = resp.json()
             block_id_list = [block.Id for block in uploaded]
             for block_id in block_id_list:
@@ -383,6 +385,7 @@ class TestBase(fixtures.BaseTestFixture):
                 if sha1 not in block_id_list:
                     raise Exception('Could not locate block {0} in response'
                                     .format(sha1))
+            return True
 
         return 200 == resp.status_code
 

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -372,7 +372,19 @@ class TestBase(fixtures.BaseTestFixture):
         data = dict([(block.Id, block.Data) for block in uploaded])
         msgpack_data = msgpack.packb(data)
         resp = self.client.upload_multiple_blocks(self.vaultname, msgpack_data)
-        return 201 == resp.status_code
+        if resp.status_code == 200:
+            block_mapping = resp.json()
+            block_id_list = [block.Id for block in uploaded]
+            for block_id in block_id_list:
+                if block_id not in block_mapping.keys():
+                    raise Exception('Could not locate block {0} in response'
+                                    .format(block_id))
+            for sha1, storageid in block_mapping.items():
+                if sha1 not in block_id_list:
+                    raise Exception('Could not locate block {0} in response'
+                                    .format(sha1))
+
+        return 200 == resp.status_code
 
     def upload_multiple_blocks(self, nblocks, size=30720):
         """

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -372,9 +372,9 @@ class TestBase(fixtures.BaseTestFixture):
         data = dict([(block.Id, block.Data) for block in uploaded])
         msgpack_data = msgpack.packb(data)
         resp = self.client.upload_multiple_blocks(self.vaultname, msgpack_data)
-        if resp.status_code == 201:
-            return True
-        elif resp.status_code == 200:
+
+        if resp.status_code == 200:
+            # Query parameter was specified
             block_mapping = resp.json()
             block_id_list = [block.Id for block in uploaded]
             for block_id in block_id_list:
@@ -387,7 +387,11 @@ class TestBase(fixtures.BaseTestFixture):
                                     .format(sha1))
             return True
 
-        return 200 == resp.status_code
+        else:
+            # otherwise it must equal 201 which doesn't have a message body to
+            # verify
+            return 201 == resp.status_code
+        
 
     def upload_multiple_blocks(self, nblocks, size=30720):
         """

--- a/tests/api/tests/test_blocks.py
+++ b/tests/api/tests/test_blocks.py
@@ -125,7 +125,7 @@ class TestUploadBlocks(base.TestBase):
         msgpacked_data = msgpack.packb(data)
         resp = self.client.upload_multiple_blocks(self.vaultname,
                                                   msgpacked_data)
-        self.assert_201_response(resp)
+        self.assert_200_response(resp)
 
     def tearDown(self):
         super(TestUploadBlocks, self).tearDown()
@@ -249,7 +249,7 @@ class TestBlockUploaded(base.TestBase):
         data = {self.blockid: self.block_data}
         msgpack_data = msgpack.packb(data)
         resp = self.client.upload_multiple_blocks(self.vaultname, msgpack_data)
-        self.assert_201_response(resp)
+        self.assert_200_response(resp)
 
         resp = self.client.block_head(self.vaultname, self.blockid)
         self.assert_204_response(resp)
@@ -581,7 +581,7 @@ class TestAssignBlocksFirst(base.TestBase):
         data = dict([(block.Id, block.Data) for block in self.blocks])
         msgpack_data = msgpack.packb(data)
         resp = self.client.upload_multiple_blocks(self.vaultname, msgpack_data)
-        self.assert_201_response(resp)
+        self.assert_200_response(resp)
 
         for block in self.blocks:
             resp = self.client.block_head(self.vaultname, block.Id)

--- a/tests/api/tests/test_blocks.py
+++ b/tests/api/tests/test_blocks.py
@@ -125,7 +125,7 @@ class TestUploadBlocks(base.TestBase):
         msgpacked_data = msgpack.packb(data)
         resp = self.client.upload_multiple_blocks(self.vaultname,
                                                   msgpacked_data)
-        self.assert_200_response(resp)
+        self.assert_201_response(resp)
 
     def tearDown(self):
         super(TestUploadBlocks, self).tearDown()
@@ -249,7 +249,7 @@ class TestBlockUploaded(base.TestBase):
         data = {self.blockid: self.block_data}
         msgpack_data = msgpack.packb(data)
         resp = self.client.upload_multiple_blocks(self.vaultname, msgpack_data)
-        self.assert_200_response(resp)
+        self.assert_201_response(resp)
 
         resp = self.client.block_head(self.vaultname, self.blockid)
         self.assert_204_response(resp)
@@ -581,7 +581,7 @@ class TestAssignBlocksFirst(base.TestBase):
         data = dict([(block.Id, block.Data) for block in self.blocks])
         msgpack_data = msgpack.packb(data)
         resp = self.client.upload_multiple_blocks(self.vaultname, msgpack_data)
-        self.assert_200_response(resp)
+        self.assert_201_response(resp)
 
         for block in self.blocks:
             resp = self.client.block_head(self.vaultname, block.Id)

--- a/tools/run_api_tests.sh
+++ b/tools/run_api_tests.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+API_TEST_ENV_NAME="env_api_tests"
+PYTHON_EXE=python2
+TESTING_HOME=~/.deuce
+TESTING_CONFIG_FILE=${TESTING_HOME}/tests.conf
+TESTING_LOGS=${TESTING_HOME}/logs
+TESTING_ROOT_LOGS=${TESTING_LOGS}/root
+TESTING_TEST_LOGS=${TESTING_LOGS}/tests
+
+DEUCE_API_TESTS_SAMPLE_TEST_CONFIG=tests/etc/tests.conf.sample
+DEUCE_API_TESTS_REQUIREMENTS=tests/test-requirements.txt
+
+
+setupEnv()
+	{
+	if [ -d ${API_TEST_ENV_NAME} ]; then
+		rm -Rf ${API_TEST_ENV_NAME}
+	fi
+	virtualenv -p `which ${PYTHON_EXE}` ${API_TEST_ENV_NAME}
+	source ${API_TEST_ENV_NAME}/bin/activate
+	pip install -r ${DEUCE_API_TESTS_REQUIREMENTS}
+	}
+
+setupTestingConfiguration()
+	{
+	echo -n "Checking for ${TESTING_HOME}..."
+	if [ -d ${TESTING_HOME} ]; then
+		echo "exists"
+	else
+		echo "creating"
+		mkdir ${TESTING_HOME}
+	fi
+
+	echo -n "Checking for ${TESTING_CONFIG_FILE}..."
+	if [ -f ${TESTING_CONFIG_FILE} ]; then
+		echo "exists"
+		echo "	Assuming configured."
+	else
+		echo "creating"
+		cp ${DEUCE_API_TESTS_SAMPLE_TEST_CONFIG} ${TESTING_CONFIG_FILE}
+		echo "Please configure ${TESTING_CONFIG_FILE}"
+		exit 1
+	fi
+
+	echo -n "Checking for ${TESTING_LOGS}..."
+	if [ -d ${TESTING_LOGS} ]; then
+		echo "exists"
+	else
+		echo "creating"
+		mkdir ${TESTING_LOGS}
+	fi
+
+	echo -n "Checking for ${TESTING_ROOT_LOGS}"
+	if [ -d ${TESTING_ROOT_LOGS} ]; then
+		echo "exists"
+	else
+		echo "creating"
+		mkdir ${TESTING_ROOT_LOGS}
+	fi
+
+	echo -n "Checking for ${TESTING_TEST_LOGS}"
+	if [ -d ${TESTING_TEST_LOGS} ]; then
+		echo "exists"
+	else
+		echo "creating"
+		mkdir ${TESTING_TEST_LOGS}
+	fi
+	}
+
+runTests()
+	{
+	pushd tests
+		export CAFE_CONFIG_FILE_PATH=${TESTING_CONFIG_FILE}
+		export CAFE_ROOT_LOG_PATH=${TESTING_ROOT_LOGS}
+		export CAFE_TEST_LOG_PATH=${TESTING_TEST_LOGS}
+		nosetests --with-xunit --nologcapture api
+	popd
+	}
+
+setupEnv
+setupTestingConfiguration
+runTests


### PR DESCRIPTION
Provide the ability for the msgpack upload to return the mapping of block id to storage id

By default (normal, optimal case), the msgpack upload returns a 201 on success and no message body.

If the caller adds the query string parameter "mapping" and a value of "True" then it will return a 200 response with a JSON message body mapping the block id to the storage id. The parameter is only utilized if it is provided and can be explicitly interpreted as a boolean value, and only triggers this response if it evaluates to True.

Update the API test to verify this behavior by using a tuple set in the msgpack upload test. The first entry in the tuple decides of the async method is used; while the second decides if the query string parameter is present.

Note: Corrects bug in API tests readme that specified the wrong location.
Note: Adds a Bash script to make it easy for anyone to run the API tests. Once OpenCAFE supports Python 3 then we can use Bash Job Control to start/stop the Deuce Server too.