### PR TITLE
feat: cassandra consistency

### DIFF
--- a/deuce/drivers/cassandra/cassandrametadatadriver.py
+++ b/deuce/drivers/cassandra/cassandrametadatadriver.py
@@ -269,6 +269,15 @@ class CassandraStorageDriver(MetadataStorageDriver):
         auth_module = importlib.import_module(
             '{0}.auth'.format(conf.metadata_driver.cassandra.db_module))
 
+        # Import the query submodule
+        query_module = importlib.import_module(
+            '{0}.query'.format(conf.metadata_driver.cassandra.db_module))
+
+        self.consistency = getattr(self.cassandra,
+                                   'ConsistencyLevel')
+        self.simplestatement = getattr(query_module,
+                                       'SimpleStatement')
+
         if conf.metadata_driver.cassandra.ssl_enabled:
             ssl_version = getattr(ssl,
                                   conf.metadata_driver.cassandra.tls_version)
@@ -288,6 +297,11 @@ class CassandraStorageDriver(MetadataStorageDriver):
             auth_provider=auth_provider,
             ssl_options=ssl_options)
 
+        if len(self._cluster.contact_points) > 2:
+            self.consistency_level = self.consistency.LOCAL_QUORUM
+        else:
+            self.consistency_level = self.consistency.ONE
+
         deuce_keyspace = conf.metadata_driver.cassandra.keyspace
         self._session = self._cluster.connect(deuce_keyspace)
 
@@ -297,7 +311,10 @@ class CassandraStorageDriver(MetadataStorageDriver):
             projectid=deuce.context.project_id,
             vaultid=vault_id
         )
-        res = self._session.execute(CQL_CREATE_VAULT, args)
+
+        query = self.simplestatement(CQL_CREATE_VAULT,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
         return
 
     def delete_vault(self, vault_id):
@@ -305,7 +322,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             projectid=deuce.context.project_id,
             vaultid=vault_id
         )
-        self._session.execute(CQL_DELETE_VAULT, args)
+        query = self.simplestatement(CQL_DELETE_VAULT,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
         return
 
     def create_vaults_generator(self, marker=None, limit=None):
@@ -314,7 +333,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             vaultid=marker or '',
             limit=self._determine_limit(limit)
         )
-        res = self._session.execute(CQL_GET_ALL_VAULTS, args)
+        query = self.simplestatement(CQL_GET_ALL_VAULTS,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
         return [row[0] for row in res]
 
     def get_vault_statistics(self, vault_id):
@@ -329,7 +350,10 @@ class CassandraStorageDriver(MetadataStorageDriver):
         )
 
         def __stats_query(cql_statement, default_value):
-            result = self._session.execute(cql_statement, args)
+            query = self.simplestatement(cql_statement,
+                consistency_level=self.consistency_level)
+            result = self._session.execute(query, args)
+
             try:
                 return result[0][0]
 
@@ -365,7 +389,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             size=0
         )
 
-        res = self._session.execute(CQL_CREATE_FILE, args)
+        query = self.simplestatement(CQL_CREATE_FILE,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         return file_id
 
@@ -377,7 +403,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             fileid=uuid.UUID(file_id)
         )
 
-        res = self._session.execute(CQL_GET_FILE_SIZE, args)
+        query = self.simplestatement(CQL_GET_FILE_SIZE,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         try:
             return int(res[0][0])
@@ -392,7 +420,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             blockid=block_id
         )
 
-        res = self._session.execute(CQL_GET_STORAGE_ID, args)
+        query = self.simplestatement(CQL_GET_STORAGE_ID,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
         try:
             return str(res[0][0])
         except IndexError:
@@ -406,7 +436,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             storageid=storage_id
         )
 
-        res = self._session.execute(CQL_GET_BLOCK_ID, args)
+        query = self.simplestatement(CQL_GET_BLOCK_ID,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
         try:
             return str(res[0][0])
         except IndexError:
@@ -419,7 +451,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             fileid=uuid.UUID(file_id)
         )
 
-        res = self._session.execute(CQL_GET_FILE, args)
+        query = self.simplestatement(CQL_GET_FILE,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         return len(res) > 0
 
@@ -431,7 +465,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             fileid=uuid.UUID(file_id)
         )
 
-        res = self._session.execute(CQL_GET_FILE, args)
+        query = self.simplestatement(CQL_GET_FILE,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         try:
             row = res[0]
@@ -447,13 +483,18 @@ class CassandraStorageDriver(MetadataStorageDriver):
             fileid=uuid.UUID(file_id)
         )
 
-        self._session.execute(CQL_DELETE_FILE, args)
+        query = self.simplestatement(CQL_DELETE_FILE,
+            consistency_level=self.consistency_level)
+        self._session.execute(query, args)
 
         # now list the file blocks and decrement the block reference count
-        res = self._session.execute(CQL_GET_ALL_FILE_BLOCKS_W_SIZE, args)
+        query = self.simplestatement(CQL_GET_ALL_FILE_BLOCKS_W_SIZE,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
-        for block_id, offset, block_size in res:
-            self._inc_block_ref_count(vault_id, block_id, -1)
+        self._inc_block_ref_counts(vault_id,
+                                   [data[0] for data in res],
+                                   -1)
 
     def finalize_file(self, vault_id, file_id, file_size=None):
         """Updates the files table to set a file to finalized. This function
@@ -469,7 +510,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             fileid=uuid.UUID(file_id)
         )
 
-        res = self._session.execute(CQL_GET_ALL_FILE_BLOCKS_W_SIZE, args)
+        query = self.simplestatement(CQL_GET_ALL_FILE_BLOCKS_W_SIZE,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         for blockid, offset, size in res:
 
@@ -523,7 +566,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
                 fileid=uuid.UUID(file_id)
             )
 
-            res = self._session.execute(CQL_FINALIZE_FILE, args)
+            query = self.simplestatement(CQL_FINALIZE_FILE,
+                consistency_level=self.consistency_level)
+            res = self._session.execute(query, args)
 
     def get_block_data(self, vault_id, block_id):
 
@@ -533,7 +578,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             blockid=block_id
         )
 
-        res = self._session.execute(CQL_GET_BLOCK_SIZE, args)
+        query = self.simplestatement(CQL_GET_BLOCK_SIZE,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         try:
             return dict(blocksize=res[0][0])
@@ -550,7 +597,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             blockid=block_id
         )
 
-        res = self._session.execute(CQL_GET_BLOCK_SIZE, args)
+        query = self.simplestatement(CQL_GET_BLOCK_SIZE,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         try:
             return res[0][0]
@@ -568,6 +617,10 @@ class CassandraStorageDriver(MetadataStorageDriver):
                 return None
 
         futures = []
+
+        query = self.simplestatement(CQL_GET_BLOCK_SIZE,
+            consistency_level=self.consistency_level)
+
         for block_id in block_ids:
             args = dict(
                 projectid=deuce.context.project_id,
@@ -575,7 +628,7 @@ class CassandraStorageDriver(MetadataStorageDriver):
                 blockid=block_id
             )
 
-            future = self._session.execute_async(CQL_GET_BLOCK_SIZE, args)
+            future = self._session.execute_async(query, args)
             futures.append(future)
         return [get_result(future.result()) for future in futures]
 
@@ -587,7 +640,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             fileid=uuid.UUID(file_id)
         )
 
-        res = self._session.execute(CQL_GET_FILE, args)
+        query = self.simplestatement(CQL_GET_FILE,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         try:
             row = res[0]
@@ -604,7 +659,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             blockid=block_id
         )
 
-        self._session.execute(CQL_MARK_BLOCK_AS_BAD, args)
+        query = self.simplestatement(CQL_MARK_BLOCK_AS_BAD,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
     @staticmethod
     def _block_exists(result, check_status):
@@ -632,13 +689,17 @@ class CassandraStorageDriver(MetadataStorageDriver):
             blockid=block_id
         )
 
-        res = self._session.execute(CQL_GET_BLOCK_STATUS, args)
+        query = self.simplestatement(CQL_GET_BLOCK_STATUS,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         return CassandraStorageDriver._block_exists(res, check_status)
 
     def has_blocks(self, vault_id, block_ids, check_status=False):
 
         futures = []
+        query = self.simplestatement(CQL_GET_BLOCK_STATUS,
+            consistency_level=self.consistency_level)
 
         for block_id in block_ids:
             args = dict(
@@ -647,7 +708,7 @@ class CassandraStorageDriver(MetadataStorageDriver):
                 blockid=block_id
             )
 
-            future = self._session.execute_async(CQL_GET_BLOCK_STATUS, args)
+            future = self._session.execute_async(query, args)
             futures.append((future, block_id))
 
         exists = lambda res: CassandraStorageDriver._block_exists(
@@ -666,7 +727,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             limit=self._determine_limit(limit)
         )
 
-        res = self._session.execute(CQL_GET_ALL_BLOCKS, args)
+        query = self.simplestatement(CQL_GET_ALL_BLOCKS,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         return [row[0] for row in res]
 
@@ -681,13 +744,16 @@ class CassandraStorageDriver(MetadataStorageDriver):
         )
 
         if marker is None:
-            query = CQL_GET_ALL_FILES
+            # query = CQL_GET_ALL_FILES
+            query = self.simplestatement(CQL_GET_ALL_FILES,
+                consistency_level=self.consistency_level)
         else:
             args.update(dict(
                 marker=uuid.UUID(marker)
             ))
-
-            query = CQL_GET_ALL_FILES_MARKER
+            query = self.simplestatement(CQL_GET_ALL_FILES_MARKER,
+                consistency_level=self.consistency_level)
+            # query = CQL_GET_ALL_FILES_MARKER
 
         res = self._session.execute(query, args)
 
@@ -703,7 +769,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
         )
 
         if limit is None:
-            query = CQL_GET_ALL_FILE_BLOCKS
+            # query = CQL_GET_ALL_FILE_BLOCKS
+            query = self.simplestatement(CQL_GET_ALL_FILE_BLOCKS,
+                consistency_level=self.consistency_level)
         else:
 
             args.update(dict(
@@ -711,7 +779,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
                 limit=self._determine_limit(limit)
             ))
 
-            query = CQL_GET_FILE_BLOCKS
+            # query = CQL_GET_FILE_BLOCKS
+            query = self.simplestatement(CQL_GET_FILE_BLOCKS,
+                consistency_level=self.consistency_level)
 
         query_res = self._session.execute(query, args)
 
@@ -725,6 +795,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
         # will probably not be allowed in the future, but for now we allow
         # this to be compatible with the other drivers.
         futures = []
+        query = self.simplestatement(CQL_ASSIGN_BLOCK_TO_FILE,
+            consistency_level=self.consistency_level)
+
         for block_id, blocksize, offset in zip(block_ids, blocksizes,
                                                offsets):
             args = dict(
@@ -736,7 +809,7 @@ class CassandraStorageDriver(MetadataStorageDriver):
                 offset=offset
             )
 
-            future = self._session.execute_async(CQL_ASSIGN_BLOCK_TO_FILE,
+            future = self._session.execute_async(query,
                                                  args)
             futures.append(future)
 
@@ -760,7 +833,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             offset=offset
         )
 
-        self._session.execute(CQL_ASSIGN_BLOCK_TO_FILE, args)
+        query = self.simplestatement(CQL_ASSIGN_BLOCK_TO_FILE,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
         self._inc_block_ref_count(vault_id, block_id)
 
     def register_block(self, vault_id, block_id, storage_id, blocksize):
@@ -775,7 +850,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
                 blocksize=int(blocksize)
             )
 
-            res = self._session.execute(CQL_REGISTER_BLOCK, args)
+            query = self.simplestatement(CQL_REGISTER_BLOCK,
+                consistency_level=self.consistency_level)
+            res = self._session.execute(query, args)
 
     def unregister_block(self, vault_id, block_id):
 
@@ -787,7 +864,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             blockid=block_id
         )
 
-        res = self._session.execute(CQL_UNREGISTER_BLOCK, args)
+        query = self.simplestatement(CQL_UNREGISTER_BLOCK,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         self._del_block_ref_count(vault_id, block_id)
 
@@ -799,7 +878,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             blockid=block_id
         )
 
-        res = self._session.execute(CQL_GET_BLOCK_REF_COUNT, args)
+        query = self.simplestatement(CQL_GET_BLOCK_REF_COUNT,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         try:
             return res[0][0]
@@ -809,6 +890,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
     def _inc_block_ref_counts(self, vault_id, block_ids, cnt=1):
 
         futures = []
+        inc_ref_count_query = self.simplestatement(CQL_INC_BLOCK_REF_COUNT,
+            consistency_level=self.consistency_level)
+
         for block_id in block_ids:
             args = dict(
                 projectid=deuce.context.project_id,
@@ -817,7 +901,7 @@ class CassandraStorageDriver(MetadataStorageDriver):
                 delta=cnt
             )
 
-            future = self._session.execute_async(CQL_INC_BLOCK_REF_COUNT, args)
+            future = self._session.execute_async(inc_ref_count_query, args)
             futures.append(future)
 
         for future in futures:
@@ -834,6 +918,8 @@ class CassandraStorageDriver(MetadataStorageDriver):
         missing_block_ids = self.has_blocks(vault_id, block_ids)
         update_block_ids = set(block_ids) - set(missing_block_ids)
         futures = []
+        update_reftime_query = self.simplestatement(CQL_UPDATE_REF_TIME,
+            consistency_level=self.consistency_level)
         for block_id in update_block_ids:
 
             reftime_args = dict(
@@ -842,7 +928,7 @@ class CassandraStorageDriver(MetadataStorageDriver):
                 blockid=block_id,
                 reftime=int(datetime.datetime.utcnow().timestamp())
             )
-            future = self._session.execute_async(CQL_UPDATE_REF_TIME,
+            future = self._session.execute_async(update_reftime_query,
                                                  reftime_args)
             futures.append(future)
 
@@ -858,7 +944,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             delta=cnt
         )
 
-        self._session.execute(CQL_INC_BLOCK_REF_COUNT, args)
+        query = self.simplestatement(CQL_INC_BLOCK_REF_COUNT,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         # The Ref-time value is stored in the blocks table
         # if the block doesn't exist then the ref-time insertion
@@ -875,7 +963,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
                 blockid=block_id,
                 reftime=int(datetime.datetime.utcnow().timestamp())
             )
-            self._session.execute(CQL_UPDATE_REF_TIME, reftime_args)
+            query = self.simplestatement(CQL_UPDATE_REF_TIME,
+                consistency_level=self.consistency_level)
+            res = self._session.execute(query, reftime_args)
 
     def _del_block_ref_count(self, vault_id, block_id):
 
@@ -885,7 +975,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             blockid=block_id
         )
 
-        self._session.execute(CQL_DEL_BLOCK_REF_COUNT, args)
+        query = self.simplestatement(CQL_DEL_BLOCK_REF_COUNT,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
     def get_block_ref_modified(self, vault_id, block_id):
 
@@ -895,7 +987,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
             blockid=block_id
         )
 
-        res = self._session.execute(CQL_GET_BLOCK_REF_TIME, args)
+        query = self.simplestatement(CQL_GET_BLOCK_REF_TIME,
+            consistency_level=self.consistency_level)
+        res = self._session.execute(query, args)
 
         try:
             return res[0][0]
@@ -905,7 +999,9 @@ class CassandraStorageDriver(MetadataStorageDriver):
     def get_health(self):
         try:
             args = ()
-            res = self._session.execute(CQL_HEALTH_CHECK, args)
+            query = self.simplestatement(CQL_HEALTH_CHECK,
+                consistency_level=self.consistency_level)
+            res = self._session.execute(query, args)
             return ["cassandra cluster: [{0}] is active".format(res[0][0])]
         except:  # pragma: no cover
             return ["cassandra is not active."]

--- a/deuce/drivers/cassandra/cassandrametadatadriver.py
+++ b/deuce/drivers/cassandra/cassandrametadatadriver.py
@@ -298,7 +298,8 @@ class CassandraStorageDriver(MetadataStorageDriver):
             ssl_options=ssl_options)
 
         if len(self._cluster.contact_points) > 2:
-            self.consistency_level = self.consistency.LOCAL_QUORUM
+            self.consistency_level = getattr(self.consistency,
+                conf.metadata_driver.cassandra.consistency)
         else:
             self.consistency_level = self.consistency.ONE
 

--- a/deuce/drivers/cassandra/cassandrametadatadriver.py
+++ b/deuce/drivers/cassandra/cassandrametadatadriver.py
@@ -297,6 +297,10 @@ class CassandraStorageDriver(MetadataStorageDriver):
             auth_provider=auth_provider,
             ssl_options=ssl_options)
 
+        # NOTE(TheSriram): We need the total number of nodes in the
+        # cluster to be greater than two, if we are going to apply
+        # any level of consistency other than ONE
+
         if len(self._cluster.contact_points) > 2:
             self.consistency_level = getattr(self.consistency,
                 conf.metadata_driver.cassandra.consistency)

--- a/deuce/drivers/metadatadriver.py
+++ b/deuce/drivers/metadatadriver.py
@@ -190,7 +190,7 @@ class MetadataStorageDriver(object):
         raise NotImplementedError
 
     @abstractmethod
-    def mark_block_as_bad(self, vault_id, block_id, check_status=False):
+    def mark_block_as_bad(self, vault_id, block_id):
         """Marks the block in the metadata driver as being a bad
         block."""
         raise NotImplementedError

--- a/deuce/drivers/sqlite/sqlitemetadatadriver.py
+++ b/deuce/drivers/sqlite/sqlitemetadatadriver.py
@@ -602,7 +602,7 @@ class SqliteStorageDriver(MetadataStorageDriver):
 
         return row
 
-    def mark_block_as_bad(self, vault_id, block_id, check_status=False):
+    def mark_block_as_bad(self, vault_id, block_id,):
         args = {
             'projectid': deuce.context.project_id,
             'vaultid': vault_id,

--- a/deuce/tests/mock_cassandra/__init__.py
+++ b/deuce/tests/mock_cassandra/__init__.py
@@ -9,13 +9,17 @@ class ConsistencyLevel(object):
     def __init__(self):
         pass
 
-    @staticmethod
-    def ONE():
-        pass
-
-    @staticmethod
-    def LOCAL_QUORUM():
-        pass
+    ANY = 0
+    ONE = 1
+    TWO = 2
+    THREE = 3
+    QUORUM = 4
+    ALL = 5
+    LOCAL_QUORUM = 6
+    EACH_QUORUM = 7
+    SERIAL = 8
+    LOCAL_SERIAL = 9
+    LOCAL_ONE = 10
 
 
 class Future(object):

--- a/deuce/tests/mock_cassandra/__init__.py
+++ b/deuce/tests/mock_cassandra/__init__.py
@@ -4,6 +4,20 @@ import deuce.drivers.cassandra.cassandrametadatadriver \
 import uuid
 
 
+class ConsistencyLevel(object):
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def ONE():
+        pass
+
+    @staticmethod
+    def LOCAL_QUORUM():
+        pass
+
+
 class Future(object):
 
     def __init__(self, result):

--- a/deuce/tests/mock_cassandra/cluster.py
+++ b/deuce/tests/mock_cassandra/cluster.py
@@ -61,9 +61,14 @@ class Cluster(object):
     def __init__(self, contact_points, auth_provider, ssl_options):
         # Create the mock driver in memory only
         self._sqliteconn = sqlite3.connect(':memory:')
+        self.cluster_contact_points = contact_points
 
         for stmt in MOCK_CASSANDRA_SCHEMA:
             self._sqliteconn.execute(stmt)
+
+    @property
+    def contact_points(self):
+        return self.cluster_contact_points
 
     def connect(self, keyspace):
         return Session(self._sqliteconn)

--- a/deuce/tests/mock_cassandra/query.py
+++ b/deuce/tests/mock_cassandra/query.py
@@ -1,0 +1,3 @@
+
+def SimpleStatement(query, consistency_level):
+    return query

--- a/deuce/tests/test_cassandra_storage_driver.py
+++ b/deuce/tests/test_cassandra_storage_driver.py
@@ -13,14 +13,17 @@ import unittest
 # against the Cassandra driver. The sqlite tests simply exercise the
 # interface.
 
+cassandra_mock = conf.metadata_driver.cassandra.testing.is_mocking
+ssl_enabled = conf.metadata_driver.cassandra.ssl_enabled
+
 
 class CassandraStorageDriverTest(SqliteStorageDriverTest):
 
     def create_driver(self):
         return CassandraStorageDriver()
 
-    @unittest.skipIf(conf.metadata_driver.cassandra.testing.is_mocking is False
-       and conf.metadata_driver.cassandra.ssl_enabled is False,
+    @unittest.skipIf(cassandra_mock is False
+       and ssl_enabled is False,
        "Don't run the test if we are running without SSL")
     def test_create_driver_auth_ssl(self):
         with patch.object(conf.metadata_driver.cassandra, 'ssl_enabled',
@@ -28,3 +31,10 @@ class CassandraStorageDriverTest(SqliteStorageDriverTest):
             with patch.object(conf.metadata_driver.cassandra, 'auth_enabled',
                               return_value=True):
                 return CassandraStorageDriver()
+
+    @unittest.skipIf(cassandra_mock is False,
+    "Dont run the test if we are against non-mocked Cassandra")
+    def test_create_driver_consistency_from_conf(self):
+        contact_points = ['127.0.0.1', '127.0.0.2', '127.0.0.3']
+        conf.metadata_driver.cassandra.cluster = contact_points
+        return CassandraStorageDriver()

--- a/ini/config.ini
+++ b/ini/config.ini
@@ -60,6 +60,7 @@ driver = deuce.drivers.disk.DiskStorageDriver
 driver = deuce.drivers.sqlite.SqliteStorageDriver
     [[cassandra]]
         cluster = 127.0.0.1,
+        consistency = ONE
         keyspace = deucekeyspace
         db_module = cassandra
         ssl_enabled = False


### PR DESCRIPTION
- If there are more than 2 nodes in the cluster, consistency is set to
  what is specified in config, otherwise its set to ONE

- Delete file also makes use of async queries to decrement reference counts