### PR TITLE
API Tests: Python3 support

### DIFF
--- a/tests/api/tests/test_block_storage.py
+++ b/tests/api/tests/test_block_storage.py
@@ -2,9 +2,9 @@ from tests.api import base
 from tests.api.utils.schema import deuce_schema
 
 import ddt
+import hashlib
 import jsonschema
 import os
-import sha
 import uuid
 
 
@@ -18,7 +18,8 @@ class TestNoBlocksUploaded(base.TestBase):
     def test_get_missing_storage_block(self):
         """Get a storage block that has not been uploaded"""
 
-        blockid = sha.new(self.id_generator(15)).hexdigest()
+        blockid = hashlib.new('sha1',
+                self.id_generator(15).encode('utf-8')).hexdigest()
         st_id = uuid.uuid5(uuid.NAMESPACE_URL, self.id_generator(50))
         storageid = '{0}_{1}'.format(blockid, st_id)
         resp = self.client.get_storage_block(self.vaultname, storageid)
@@ -27,7 +28,8 @@ class TestNoBlocksUploaded(base.TestBase):
     def test_head_missing_storage_block(self):
         """Head a block that has not been uploaded"""
 
-        blockid = sha.new(self.id_generator(15)).hexdigest()
+        blockid = hashlib.new('sha1',
+                self.id_generator(15).encode('utf-8')).hexdigest()
         st_id = uuid.uuid5(uuid.NAMESPACE_URL, self.id_generator(50))
         storageid = '{0}_{1}'.format(blockid, st_id)
         resp = self.client.storage_block_head(self.vaultname, storageid)
@@ -38,7 +40,8 @@ class TestNoBlocksUploaded(base.TestBase):
         Block not present in metadata"""
 
         self.generate_block_data()
-        blockid = sha.new(self.id_generator(15)).hexdigest()
+        blockid = hashlib.new('sha1',
+                self.id_generator(15).encode('utf-8')).hexdigest()
         st_id = uuid.uuid5(uuid.NAMESPACE_URL, self.id_generator(50))
         storageid = '{0}_{1}'.format(blockid, st_id)
         resp = self.client.upload_storage_block(self.vaultname, storageid,
@@ -60,7 +63,8 @@ class TestNoBlocksUploaded(base.TestBase):
     def test_delete_missing_storage_block(self):
         """Delete a storage block that has not been uploaded"""
 
-        blockid = sha.new(self.id_generator(15)).hexdigest()
+        blockid = hashlib.new('sha1',
+                self.id_generator(15).encode('utf-8')).hexdigest()
         st_id = uuid.uuid5(uuid.NAMESPACE_URL, self.id_generator(50))
         storageid = '{0}_{1}'.format(blockid, st_id)
         resp = self.client.delete_storage_block(self.vaultname, storageid)
@@ -291,7 +295,7 @@ class TestListStorageBlocks(base.TestBase):
         """
 
         url = None
-        for i in range(20 / value - pages):
+        for i in range(int(20 / value) - pages):
             if not url:
                 resp = self.client.list_of_storage_blocks(self.vaultname,
                                                   marker=marker, limit=value)
@@ -300,7 +304,7 @@ class TestListStorageBlocks(base.TestBase):
 
             self.assert_200_response(resp)
 
-            if i < 20 / value - (1 + pages):
+            if i < int(20 / value) - (1 + pages):
                 self.assertIn('x-next-batch', resp.headers)
                 url = resp.headers['x-next-batch']
                 self.assertUrl(url, storage=True, nextlist=True)
@@ -323,7 +327,8 @@ class TestListStorageBlocks(base.TestBase):
     def test_list_storage_blocks_invalid_marker(self):
         """Request a Storage Block List with an invalid marker"""
 
-        bad_marker = sha.new(self.id_generator(50)).hexdigest()
+        bad_marker = hashlib.new('sha1',
+                self.id_generator(50).encode('utf-8')).hexdigest()
         resp = self.client.list_of_storage_blocks(self.vaultname,
                 marker=bad_marker)
         self.assert_404_response(resp)
@@ -331,7 +336,8 @@ class TestListStorageBlocks(base.TestBase):
     def test_list_storage_blocks_bad_marker(self):
         """Request a Storage Block List with a bad marker"""
 
-        blockid = sha.new(self.id_generator(15)).hexdigest()
+        blockid = hashlib.new('sha1',
+                self.id_generator(15).encode('utf-8')).hexdigest()
         st_id = uuid.uuid5(uuid.NAMESPACE_URL, self.id_generator(50))
         bad_storageid = '{0}_{1}'.format(blockid, st_id)
         resp = self.client.list_of_storage_blocks(self.vaultname,

--- a/tests/api/tests/test_vaults.py
+++ b/tests/api/tests/test_vaults.py
@@ -3,8 +3,12 @@ from tests.api.utils.schema import deuce_schema
 
 import ddt
 import jsonschema
-import urlparse
 import time
+
+try:
+    import urllib.parse as urlparse
+except ImportError:
+    import urlparse
 
 
 class TestNoVaultsCreated(base.TestBase):

--- a/tests/api/utils/client.py
+++ b/tests/api/utils/client.py
@@ -1,7 +1,7 @@
 import uuid
 
 from cafe.engine.http import client
-from tests.api.utils.models import auth_requests, auth_response
+from .models import auth_requests, auth_response
 
 
 class AuthClient(client.AutoMarshallingHTTPClient):
@@ -25,8 +25,7 @@ class AuthClient(client.AutoMarshallingHTTPClient):
         """
         request_obj = auth_requests.AuthUsernameApiKey(username, api_key)
         resp = self.request('POST', self.url + '/tokens',
-                            request_entity=request_obj,
-                            response_entity_type=auth_response.AuthToken)
+                            request_entity=request_obj)
         return resp
 
 

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -3,4 +3,4 @@ nose
 ddt
 jsonschema
 msgpack-python
-opencafe
+git+https://github.com/stackforge/opencafe.git#egg=opencafe


### PR DESCRIPTION
Changes made to the API Tests to work with Python 3.4 Nosetests.
Changes made:
* requirements file modified to get OpenCAFE from its repo, as opposed to the pip package (the package is out of date)
* import statement using relative paths start with dot
* replaced deprecated sha library with hashlib
* added python 3 import statement for urllib
* division operation that resulted in a float was casted to int
* stopped using OpenCAFE Response Entity (because there is no support for it with Python 3).


Note: May remove the file:
tests/api/utils/models/auth_response.py
since it is no longer used.