### PR TITLE
fix: downloading a corrupt file should not a cause a 500

### DIFF
--- a/deuce/drivers/blockstoragedriver.py
+++ b/deuce/drivers/blockstoragedriver.py
@@ -107,7 +107,8 @@ class BlockStorageDriver(object):
         """Returns a generator of file-like objects that are
         ready to read. These objects will get closed
         individually."""
-        return (self.get_block_obj(vault_id, storage_block_id)
+        return ((storage_block_id,
+                 self.get_block_obj(vault_id, storage_block_id))
             for storage_block_id in storage_block_gen)
 
     @staticmethod

--- a/deuce/tests/test_disk_storage_driver.py
+++ b/deuce/tests/test_disk_storage_driver.py
@@ -225,7 +225,8 @@ class DiskStorageDriverTest(V1Base):
 
         for x in range(0, len(fetched_data)):
             blocks[x].seek(0)
-            assert fetched_data[x].read() == blocks[x].read()
+            storage_id, obj = fetched_data[x]
+            assert obj.read() == blocks[x].read()
 
         # Clenaup.
         for storage_id in storage_ids[:]:

--- a/deuce/tests/test_disk_storage_driver.py
+++ b/deuce/tests/test_disk_storage_driver.py
@@ -226,7 +226,7 @@ class DiskStorageDriverTest(V1Base):
         for x in range(0, len(fetched_data)):
             blocks[x].seek(0)
             storage_id, obj = fetched_data[x]
-            assert obj.read() == blocks[x].read()
+            self.assertEqual(obj.read(), blocks[x].read())
 
         # Clenaup.
         for storage_id in storage_ids[:]:

--- a/deuce/tests/test_files.py
+++ b/deuce/tests/test_files.py
@@ -142,7 +142,8 @@ class TestFiles(ControllerTest):
     def test_get_corrupt_file(self):
 
         enough_num = 10
-        bad_file_gen = (None for _ in range(enough_num))
+        bad_file_gen = ((self.create_storage_block_id(), None)
+                        for _ in range(enough_num))
 
         with patch.object(Vault, 'get_blocks_generator',
                           return_value=bad_file_gen):

--- a/deuce/transport/wsgi/v1_0/files.py
+++ b/deuce/transport/wsgi/v1_0/files.py
@@ -107,11 +107,11 @@ class ItemResource(object):
         # object instead of an iterator.
 
         def premature_close(storage_id):
-            msg = '[{0}/{1}/{2}/{3}] is missing ' \
-                  'from storage backend'.format(deuce.context.project_id,
-                                                vault_id,
-                                                file_id,
-                                                storage_id)
+            msg = '[{0}/{1}/{2}] is missing data' \
+                  'for storage block {3}'.format(deuce.context.project_id,
+                                                 vault_id,
+                                                 file_id,
+                                                 storage_id)
             logger.error(msg)
             raise StopIteration(msg)
 

--- a/deuce/transport/wsgi/v1_0/files.py
+++ b/deuce/transport/wsgi/v1_0/files.py
@@ -106,11 +106,17 @@ class ItemResource(object):
         # we should be able to set resp.stream to any file like
         # object instead of an iterator.
 
-        def premature_close():
-            raise StopIteration
+        def premature_close(storage_id):
+            msg = '[{0}/{1}/{2}/{3}] is missing ' \
+                  'from storage backend'.format(deuce.context.project_id,
+                                                vault_id,
+                                                file_id,
+                                                storage_id)
+            logger.error(msg)
+            raise StopIteration(msg)
 
-        resp.stream = (obj.read() if obj else premature_close()
-                       for obj in objs)
+        resp.stream = (obj.read() if obj else premature_close(storageid)
+                       for (storageid, obj) in objs)
         resp.status = falcon.HTTP_200
         resp.set_header('Content-Length', str(vault.get_file_length(file_id)))
         resp.content_type = 'application/octet-stream'

--- a/deuce/transport/wsgi/v1_0/files.py
+++ b/deuce/transport/wsgi/v1_0/files.py
@@ -105,7 +105,12 @@ class ItemResource(object):
         # NOTE(TheSriram): falcon 0.2.0 might fix this problem,
         # we should be able to set resp.stream to any file like
         # object instead of an iterator.
-        resp.stream = (obj.read() for obj in objs)
+
+        def premature_close():
+            raise StopIteration
+
+        resp.stream = (obj.read() if obj else premature_close()
+                       for obj in objs)
         resp.status = falcon.HTTP_200
         resp.set_header('Content-Length', str(vault.get_file_length(file_id)))
         resp.content_type = 'application/octet-stream'


### PR DESCRIPTION
- Handled in such a way as to immediately stop generator, if a bad
  block is encountered by raising StopIteration