### PR TITLE
Bugfix swift get object

### DIFF
--- a/deuce/tests/test_cassandra_storage_driver.py
+++ b/deuce/tests/test_cassandra_storage_driver.py
@@ -35,6 +35,17 @@ class CassandraStorageDriverTest(SqliteStorageDriverTest):
                               return_value=True):
                 return CassandraStorageDriver()
 
+    # (BenjamenMeyer) Covers the contact_point switching when
+    # the ~/.deuce/config.ini is not available
+    @unittest.skipIf(cassandra_mock is False,
+    "Dont run the test if we are against non-mocked Cassandra")
+    def test_create_driver_consistency_from_conf(self):
+        contact_points = ['127.0.0.1', '127.0.0.2', '127.0.0.3']
+        conf.metadata_driver.cassandra.cluster = contact_points
+        return CassandraStorageDriver()
+
+    # (BenjamenMeyer) Covers the contact_point switching when
+    # the ~/.deuce/config.ini is available
     @ddt.data(['127.0.0.1', '127.0.0.2', '127.0.0.3'], ['127.0.0.1'])
     def test_create_driver_mocked_consistency(self, contact_points):
         # We want the actual imports for 3 of the 4 imports

--- a/deuce/tests/test_cassandra_storage_driver.py
+++ b/deuce/tests/test_cassandra_storage_driver.py
@@ -55,6 +55,7 @@ class CassandraStorageDriverTest(SqliteStorageDriverTest):
             ]
             # override the connect method so it doesn't actually do anything
             mock_importlib.return_value[1].connect = MagicMock()
+            mock_importlib.return_value[1].contact_points = contact_points
 
             conf.metadata_driver.cassandra.cluster = contact_points
             return CassandraStorageDriver()

--- a/deuce/tests/test_p3kswiftclient.py
+++ b/deuce/tests/test_p3kswiftclient.py
@@ -234,20 +234,20 @@ class Test_P3k_SwiftClient(V1Base):
                               'mock'))
 
     def test_get_object(self):
-        file = MockFile(10)
-        r = Response(200, file)
+        mock_file = MockFile(10)
+        r = Response(200, mock_file)
         fut1 = asyncio.Future(loop=None)
         fut1.set_result(r)
         p3k_swiftclient.aiohttp.request = mock.Mock(return_value=fut1)
 
-        response = p3k_swiftclient.get_object(
+        response, block = p3k_swiftclient.get_object(
             self.storage_url,
             self.token,
             self.vault,
             self.block,
             self.response_dict)
-        self.assertEqual(file, response[0])
-        self.assertEqual(r.headers, response[1].headers)
+        self.assertEqual(r, response)
+        self.assertEqual(mock_file, block)
 
     def test_delete_object(self):
         r = Response(204)

--- a/deuce/util/client.py
+++ b/deuce/util/client.py
@@ -194,7 +194,7 @@ def delete_object(url, token, container, name, response_dict):
 
 def get_object(url, token, container, name, response_dict):
     headers = {'X-Auth-Token': token}
-    (response, resp_headers) = _request_getobj(
+    (response, block) = _request_getobj(
         'GET',
         url +
         '/' +
@@ -205,4 +205,4 @@ def get_object(url, token, container, name, response_dict):
 
     response_dict['status'] = response.status
 
-    return (resp_headers, response)
+    return (response, block)


### PR DESCRIPTION
Bug Fix: swift driver async utility had wrong arguments for get_object()
Bug Fix: Cassandra Driver no longer had full test coverage under some configurations