### PR TITLE
feat: PATCH /v1.0/vaults/{vault_id}/blocks

### DIFF
--- a/deuce/drivers/cassandra/cassandrametadatadriver.py
+++ b/deuce/drivers/cassandra/cassandrametadatadriver.py
@@ -785,10 +785,7 @@ class CassandraStorageDriver(MetadataStorageDriver):
             for future in futures:
                 future.result()
 
-            if len(block_ids) != limit:
-                return
-            else:
-                self.reset_block_status(vault_id, block_ids[-1:][0], limit)
+            return block_ids[-1:][0] if len(block_ids) == limit else None
 
         query_args = dict(
             projectid=deuce.context.project_id,
@@ -801,7 +798,8 @@ class CassandraStorageDriver(MetadataStorageDriver):
             consistency_level=self.consistency_level)
         future = self._session.execute_async(query, query_args)
 
-        mark_block_as_good(future.result(), self._determine_limit(limit))
+        return mark_block_as_good(future.result(),
+                                  self._determine_limit(limit))
 
     def mark_block_as_bad(self, vault_id, block_id):
 

--- a/deuce/drivers/metadatadriver.py
+++ b/deuce/drivers/metadatadriver.py
@@ -204,6 +204,12 @@ class MetadataStorageDriver(object):
         raise NotImplementedError
 
     @abstractmethod
+    def reset_block_status(self, vault_id, marker=None, limit=None):
+        """Marks the blocks for a given vault in the metadata driver
+        as good blocks."""
+        raise NotImplementedError
+
+    @abstractmethod
     def has_block(self, vault_id, block_id, check_status=False):
         """Determines if the vault has the specified block.
 

--- a/deuce/drivers/metadatadriver.py
+++ b/deuce/drivers/metadatadriver.py
@@ -204,7 +204,8 @@ class MetadataStorageDriver(object):
         raise NotImplementedError
 
     @abstractmethod
-    def reset_block_status(self, vault_id, marker=None, limit=None):
+    def reset_block_status(self, vault_id, marker=None,
+                           limit=None):
         """Marks the blocks for a given vault in the metadata driver
         as good blocks."""
         raise NotImplementedError

--- a/deuce/drivers/mongodb/mongodbmetadatadriver.py
+++ b/deuce/drivers/mongodb/mongodbmetadatadriver.py
@@ -404,12 +404,8 @@ class MongoDbStorageDriver(MetadataStorageDriver):
         for block in blocks:
             mark_block_as_good(vault_id, block)
 
-        if len(blocks) != self._determine_limit(limit):
-            return
-        else:
-            self.reset_block_status(vault_id,
-                                    marker=blocks[-1:][0],
-                                    limit=self._determine_limit(limit))
+        return blocks[-1:][0] if len(blocks) == \
+            self._determine_limit(limit) else None
 
     def has_block(self, vault_id, block_id, check_status=False):
         # Query BLOCKS for the block

--- a/deuce/drivers/mongodb/mongodbmetadatadriver.py
+++ b/deuce/drivers/mongodb/mongodbmetadatadriver.py
@@ -385,7 +385,8 @@ class MongoDbStorageDriver(MetadataStorageDriver):
 
         def mark_block_as_good(vault_id, block_id):
             args = {
-                'projectid': deuce.context.project_id, 'vaultid': vault_id,
+                'projectid': deuce.context.project_id,
+                'vaultid': vault_id,
                 'blockid': str(block_id)
             }
 

--- a/deuce/drivers/sqlite/sqlitemetadatadriver.py
+++ b/deuce/drivers/sqlite/sqlitemetadatadriver.py
@@ -709,13 +709,8 @@ class SqliteStorageDriver(MetadataStorageDriver):
         for block in blocks:
             mark_block_as_good(vault_id, block)
 
-        if len(blocks) != self._determine_limit(limit):
-            return
-
-        else:
-
-            self.reset_block_status(vault_id, marker=blocks[-1:][0],
-                                    limit=self._determine_limit(limit))
+        return blocks[-1:][0] if len(blocks) == \
+            self._determine_limit(limit) else None
 
     def has_block(self, vault_id, block_id, check_status=False):
         # Query the blocks table

--- a/deuce/model/vault.py
+++ b/deuce/model/vault.py
@@ -142,10 +142,18 @@ class Vault(object):
         else:
             return False
 
+    def reset_block_status_marker(self, marker):
+        return deuce.metadata_driver.reset_block_status(self.id,
+                marker=marker)
+
     def reset_block_status(self):
-        deuce.metadata_driver.reset_block_status(self.id,
-            marker=None,
-            limit=None)
+        marker = None
+        while True:
+            end_marker = self.reset_block_status_marker(marker)
+            if end_marker:
+                marker = end_marker
+            else:
+                break
 
     def _storage_has_block(self, block_id):
         return deuce.storage_driver.block_exists(self.id,

--- a/deuce/model/vault.py
+++ b/deuce/model/vault.py
@@ -2,6 +2,7 @@ from deuce.model.block import Block
 from deuce.model.file import File
 from deuce.model.exceptions import ConsistencyError
 from deuce.util import log as logging
+from deuce import conf
 
 import deuce
 import uuid
@@ -140,6 +141,11 @@ class Vault(object):
             return True
         else:
             return False
+
+    def reset_block_status(self):
+        deuce.metadata_driver.reset_block_status(self.id,
+            marker=None,
+            limit=None)
 
     def _storage_has_block(self, block_id):
         return deuce.storage_driver.block_exists(self.id,

--- a/deuce/tests/mock_cassandra/__init__.py
+++ b/deuce/tests/mock_cassandra/__init__.py
@@ -31,6 +31,13 @@ class Future(object):
 
         return [element for element in self._result] if self._result else []
 
+    def add_callbacks(self, callback=None, errback=None, callback_args=(),
+                      callback_kwargs={}):
+        try:
+            callback(self.result(), **callback_kwargs)
+        except Exception as ex:
+            errback(ex)
+
 
 class Session(object):
 

--- a/deuce/tests/mock_cassandra/__init__.py
+++ b/deuce/tests/mock_cassandra/__init__.py
@@ -28,7 +28,6 @@ class Future(object):
         self._result = result
 
     def result(self):
-
         return [element for element in self._result] if self._result else []
 
     def add_callbacks(self, callback=None, errback=None, callback_args=(),

--- a/deuce/tests/test_blocks.py
+++ b/deuce/tests/test_blocks.py
@@ -192,6 +192,16 @@ class TestBlocksController(ControllerTest):
                                       body=request_body)
         self.assertEqual(self.srmock.status, falcon.HTTP_412)
 
+    def test_reset_block_status(self):
+        path = self.get_blocks_path(self.vault_name)
+
+        invalid_path = self.get_blocks_path('bogus_vault')
+        response = self.simulate_patch(invalid_path, headers=self._hdrs)
+        self.assertEqual(self.srmock.status, falcon.HTTP_404)
+
+        response = self.simulate_patch(path, headers=self._hdrs)
+        self.assertEqual(self.srmock.status, falcon.HTTP_204)
+
     def test_post_invalid_request_body(self):
         path = self.get_blocks_path(self.vault_name)
 

--- a/deuce/tests/test_cassandra_storage_driver.py
+++ b/deuce/tests/test_cassandra_storage_driver.py
@@ -5,7 +5,6 @@ import ddt
 from mock import patch, MagicMock
 
 from deuce.drivers.cassandra import CassandraStorageDriver
-from deuce.tests.mock_cassandra import Future
 from deuce.tests.test_sqlite_storage_driver import SqliteStorageDriverTest
 from deuce import conf
 
@@ -71,13 +70,3 @@ class CassandraStorageDriverTest(SqliteStorageDriverTest):
 
             conf.metadata_driver.cassandra.cluster = contact_points
             return CassandraStorageDriver()
-
-    @unittest.skipIf(cassandra_mock is False,
-    "Dont run the test if we are against non-mocked Cassandra")
-    def test_reset_block_exception(self):
-        driver = self.create_driver()
-        vault = self.create_vault_id()
-        driver.create_vault(vault)
-        with patch.object(Future, 'result', return_value=None):
-                driver.reset_block_status(vault)
-

--- a/deuce/tests/test_cassandra_storage_driver.py
+++ b/deuce/tests/test_cassandra_storage_driver.py
@@ -5,6 +5,7 @@ import ddt
 from mock import patch, MagicMock
 
 from deuce.drivers.cassandra import CassandraStorageDriver
+from deuce.tests.mock_cassandra import Future
 from deuce.tests.test_sqlite_storage_driver import SqliteStorageDriverTest
 from deuce import conf
 
@@ -70,3 +71,13 @@ class CassandraStorageDriverTest(SqliteStorageDriverTest):
 
             conf.metadata_driver.cassandra.cluster = contact_points
             return CassandraStorageDriver()
+
+    @unittest.skipIf(cassandra_mock is False,
+    "Dont run the test if we are against non-mocked Cassandra")
+    def test_reset_block_exception(self):
+        driver = self.create_driver()
+        vault = self.create_vault_id()
+        driver.create_vault(vault)
+        with patch.object(Future, 'result', return_value=None):
+                driver.reset_block_status(vault)
+

--- a/deuce/tests/test_sqlite_storage_driver.py
+++ b/deuce/tests/test_sqlite_storage_driver.py
@@ -828,7 +828,6 @@ class SqliteStorageDriverTest(V1Base):
             sorted(driver.has_blocks(vault_id, block_ids, check_status=True)),
             sorted(bad_block_ids))
 
-
     def test_assign_bad_blocks(self):
         driver = self.create_driver()
         vault_id = self.create_vault_id()
@@ -893,6 +892,9 @@ class SqliteStorageDriverTest(V1Base):
 
         block_ids = ['block_{0}'.format(id) for id in range(0, num_blocks)]
 
+        # Reset block status, when there are no blocks in the vault
+        driver.reset_block_status(vault_id)
+
         for bid in block_ids:
             driver.register_block(vault_id, bid,
                 self._genstorageid(bid), 1024)
@@ -910,7 +912,7 @@ class SqliteStorageDriverTest(V1Base):
         self.assertEqual(driver.has_blocks(vault_id, block_ids,
             check_status=True), [])
 
-        # reset block_status across the vault
+        # mark blocks as bad, across the vault
         for bid in block_ids:
             driver.mark_block_as_bad(vault_id, bid)
 
@@ -920,6 +922,7 @@ class SqliteStorageDriverTest(V1Base):
         self.assertEqual(driver.has_blocks(vault_id, block_ids,
             check_status=True), block_ids)
 
+        # reset block status, across the vault
         driver.reset_block_status(vault_id)
 
         # Now check has_blocks. None of the blocks are bad so

--- a/deuce/tests/test_sqlite_storage_driver.py
+++ b/deuce/tests/test_sqlite_storage_driver.py
@@ -892,8 +892,23 @@ class SqliteStorageDriverTest(V1Base):
 
         block_ids = ['block_{0}'.format(id) for id in range(0, num_blocks)]
 
+        def reset_block_status_marker(marker):
+            return driver.reset_block_status(vault_id,
+                    marker=marker)
+        # reset block status, across the vault
+
+        def reset_block_status():
+
+            marker = None
+            while True:
+                end_marker = reset_block_status_marker(marker)
+                if end_marker:
+                    marker = end_marker
+                else:
+                    break
+
         # Reset block status, when there are no blocks in the vault
-        driver.reset_block_status(vault_id)
+        reset_block_status()
 
         for bid in block_ids:
             driver.register_block(vault_id, bid,
@@ -922,8 +937,8 @@ class SqliteStorageDriverTest(V1Base):
         self.assertEqual(driver.has_blocks(vault_id, block_ids,
             check_status=True), block_ids)
 
-        # reset block status, across the vault
-        driver.reset_block_status(vault_id)
+        # Reset block status for all blocks under the given vault
+        reset_block_status()
 
         # Now check has_blocks. None of the blocks are bad so
         # the list returned should be empty

--- a/deuce/tests/test_sqlite_storage_driver.py
+++ b/deuce/tests/test_sqlite_storage_driver.py
@@ -1,15 +1,16 @@
+import ddt
+from mock import MagicMock
+import random
+
 from deuce.tests import V1Base
 from deuce.drivers.metadatadriver import MetadataStorageDriver, GapError,\
     OverlapError, ConstraintError
 from deuce.drivers.sqlite import SqliteStorageDriver
 from deuce.drivers import BlockStorageDriver
-import random
-
 import deuce
 
-from mock import MagicMock
 
-
+@ddt.ddt
 class SqliteStorageDriverTest(V1Base):
 
     def _genstorageid(self, blockid):
@@ -827,6 +828,7 @@ class SqliteStorageDriverTest(V1Base):
             sorted(driver.has_blocks(vault_id, block_ids, check_status=True)),
             sorted(bad_block_ids))
 
+
     def test_assign_bad_blocks(self):
         driver = self.create_driver()
         vault_id = self.create_vault_id()
@@ -881,6 +883,49 @@ class SqliteStorageDriverTest(V1Base):
         driver.finalize_file(vault_id,
                              file_id,
                              1024 * len(bad_block_ids))
+
+    @ddt.data(50, 100, 150, 200)
+    def test_reset_block_status(self, total_blocks):
+        driver = self.create_driver()
+        vault_id = self.create_vault_id()
+
+        num_blocks = total_blocks
+
+        block_ids = ['block_{0}'.format(id) for id in range(0, num_blocks)]
+
+        for bid in block_ids:
+            driver.register_block(vault_id, bid,
+                self._genstorageid(bid), 1024)
+
+        # All of these blocks should exist, and none should be bad.
+        for bid in block_ids:
+            self.assertEqual(driver.has_block(vault_id, bid,
+                check_status=False), True)
+
+            self.assertEqual(driver.has_block(vault_id, bid,
+                check_status=True), True)
+
+        # Now check has_blocks. None of the blocks are bad so
+        # the list returned should be empty
+        self.assertEqual(driver.has_blocks(vault_id, block_ids,
+            check_status=True), [])
+
+        # reset block_status across the vault
+        for bid in block_ids:
+            driver.mark_block_as_bad(vault_id, bid)
+
+        # Now check has_blocks. All of the blocks are bad so
+        # the list returned should be all the blocks in the vault.
+
+        self.assertEqual(driver.has_blocks(vault_id, block_ids,
+            check_status=True), block_ids)
+
+        driver.reset_block_status(vault_id)
+
+        # Now check has_blocks. None of the blocks are bad so
+        # the list returned should be empty
+        self.assertEqual(driver.has_blocks(vault_id, block_ids,
+            check_status=True), [])
 
     def test_file_block_generator_marker_limit(self):
         driver = self.create_driver()

--- a/deuce/transport/wsgi/v1_0/blocks.py
+++ b/deuce/transport/wsgi/v1_0/blocks.py
@@ -286,3 +286,15 @@ class CollectionResource(object):
 
         resp.body = json.dumps([response.metadata_block_id
                                 for response in responses])
+
+    @validate(vault_id=VaultGetRule)
+    def on_patch(self, req, resp, vault_id):
+
+        vault = Vault.get(vault_id)
+        if not vault:
+            logger.error('Vault [{0}] does not exist'.format(vault_id))
+            raise errors.HTTPNotFound
+
+        vault.reset_block_status()
+
+        resp.status = falcon.HTTP_204


### PR DESCRIPTION
This endpoint, sets all the blocks' isinvalid flag, to be False.
It can be used to troubleshoot a vault's status, and start things
afresh